### PR TITLE
Allow unauthenticated access to the sentencetypes read endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/OpenApiConfiguration.kt
@@ -21,7 +21,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
     .servers(
       listOf(
         Server().url("https://remand-and-sentencing-api.hmpps.service.justice.gov.uk").description("Prod"),
-        Server().url("https://remand-and-sentencing-api-preprod.hmpps.service.justice.gov.ukk").description("Preprod"),
+        Server().url("https://remand-and-sentencing-api-preprod.hmpps.service.justice.gov.uk").description("Preprod"),
         Server().url("https://remand-and-sentencing-api-dev.hmpps.service.justice.gov.uk").description("Development"),
         Server().url("http://localhost:8080").description("Local"),
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/ResourceServerConfiguration.kt
@@ -30,6 +30,7 @@ class ResourceServerConfiguration {
           "/swagger-ui/**",
           "/swagger-ui.html",
           "/h2-console/**",
+          "/legacy/sentence-type/**"
         ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/ResourceServerConfiguration.kt
@@ -30,7 +30,7 @@ class ResourceServerConfiguration {
           "/swagger-ui/**",
           "/swagger-ui.html",
           "/h2-console/**",
-          "/legacy/sentence-type/**"
+          "/legacy/sentence-type/**",
         ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }


### PR DESCRIPTION
* Fix to spelling of remand and sentencing API in preprod
* Allow /legacy/sentence-type/