### PR TITLE
Add SentenceTypeDetail DTO for full sentence type detail in legacy service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/SentenceTypeDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/SentenceTypeDetail.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto
+
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.SentenceTypeEntity
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ReferenceEntityStatus
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.SentenceTypeClassification
+import java.time.LocalDate
+import java.util.UUID
+
+data class SentenceTypeDetail(
+  val sentenceTypeUuid: UUID,
+  val description: String,
+  val minAgeInclusive: Int?,
+  val maxAgeExclusive: Int?,
+  val minDateInclusive: LocalDate?,
+  val maxDateExclusive: LocalDate?,
+  val minOffenceDateInclusive: LocalDate?,
+  val maxOffenceDateExclusive: LocalDate?,
+  val classification: SentenceTypeClassification,
+  val hintText: String?,
+  val nomisCjaCode: String,
+  val nomisSentenceCalcType: String,
+  val displayOrder: Int,
+  val status: ReferenceEntityStatus,
+) {
+  companion object {
+    fun from(entity: SentenceTypeEntity): SentenceTypeDetail = SentenceTypeDetail(
+      sentenceTypeUuid = entity.sentenceTypeUuid,
+      description = entity.description,
+      minAgeInclusive = entity.minAgeInclusive,
+      maxAgeExclusive = entity.maxAgeExclusive,
+      minDateInclusive = entity.minDateInclusive,
+      maxDateExclusive = entity.maxDateExclusive,
+      minOffenceDateInclusive = entity.minOffenceDateInclusive,
+      maxOffenceDateExclusive = entity.maxOffenceDateExclusive,
+      classification = entity.classification,
+      hintText = entity.hintText,
+      nomisCjaCode = entity.nomisCjaCode,
+      nomisSentenceCalcType = entity.nomisSentenceCalcType,
+      displayOrder = entity.displayOrder,
+      status = entity.status,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/dto/LegacySentenceType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/dto/LegacySentenceType.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.SentenceType
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.SentenceTypeDetail
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.SentenceTypeClassification
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.SentenceTypePeriodDefinitions
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.model.RecallType
@@ -18,7 +18,7 @@ data class LegacySentenceType(
   val sentencingAct: Int,
   val eligibility: SentenceEligibility?,
   val recallType: RecallType,
-  val inputSentenceType: SentenceType?,
+  val inputSentenceType: SentenceTypeDetail?,
   val nomisActive: Boolean,
   val nomisDescription: String,
   val nomisExpiryDate: LocalDate?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceTypesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceTypesService.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.service
 
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.SentenceType
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.SentenceTypeDetail
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.LegacySentenceTypeEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.SentenceTypeClassification
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.SentenceTypePeriodDefinition
@@ -47,7 +47,7 @@ class LegacySentenceTypesService(private val legacySentenceTypeRepository: Legac
       nomisExpiryDate = nomisExpiryDate,
       eligibility = eligibility,
       recallType = RecallTypeIdentifier.from(recallType).toDomain(),
-      inputSentenceType = sentenceType?.let { SentenceType.from(it) },
+      inputSentenceType = sentenceType?.let { SentenceTypeDetail.from(it) },
       nomisTermTypes = safeNomisTerms.associate { it.name to it.description },
       sentencingAct = sentencingAct,
     )


### PR DESCRIPTION
Replaces use of SentenceType with SentenceTypeDetail in LegacySentenceType, allowing full sentence type metadata to be exposed, including age/date limits, classification, status, and NOMIS mapping.