### PR TITLE
RASS-955 Remove requirement to pass in prisonId (for legacy routes) to create/update sentences and periodLengths

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/PeriodLengthEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/PeriodLengthEntity.kt
@@ -39,7 +39,7 @@ class PeriodLengthEntity(
   var statusId: EntityStatus,
   val createdAt: ZonedDateTime = ZonedDateTime.now(),
   val createdBy: String,
-  val createdPrison: String?,
+  val createdPrison: String? = null,
   var updatedAt: ZonedDateTime? = null,
   var updatedBy: String? = null,
   var updatedPrison: String? = null,
@@ -101,7 +101,6 @@ class PeriodLengthEntity(
     legacyData = if (type == PeriodLengthType.UNSUPPORTED) periodLength.legacyData else null
     updatedAt = ZonedDateTime.now()
     updatedBy = username
-    updatedPrison = periodLength.prisonId
   }
 
   fun copy(): PeriodLengthEntity = PeriodLengthEntity(
@@ -164,7 +163,6 @@ class PeriodLengthEntity(
         appearanceEntity = null,
         legacyData = legacyData,
         createdBy = createdBy,
-        createdPrison = periodLength.prisonId,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/RecallEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/RecallEntity.kt
@@ -91,7 +91,6 @@ class RecallEntity(
       returnToCustodyDate = if (recallType.code.isFixedTermRecall()) sentence.returnToCustodyDate else null,
       recallType = recallType,
       createdByUsername = createdByUsername,
-      createdPrison = sentence.prisonId,
       statusId = EntityStatus.ACTIVE,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/RecallSentenceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/RecallSentenceEntity.kt
@@ -61,7 +61,6 @@ class RecallSentenceEntity(
       sentence = createdSentence,
       recall = recall,
       createdByUsername = createdByUsername,
-      createdPrison = sentence.prisonId,
       legacyData = legacyData,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/SentenceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/SentenceEntity.kt
@@ -45,7 +45,7 @@ class SentenceEntity(
   @Column
   val createdBy: String,
   @Column
-  val createdPrison: String?,
+  val createdPrison: String? = null,
   var updatedAt: ZonedDateTime? = null,
   var updatedBy: String? = null,
   var updatedPrison: String? = null,
@@ -121,7 +121,6 @@ class SentenceEntity(
         EntityStatus.INACTIVE
       },
       createdBy = createdBy,
-      createdPrison = sentence.prisonId,
       supersedingSentence = this,
       charge = charge,
       sentenceServeType = if (consecutiveTo != null) "CONSECUTIVE" else "UNKNOWN",
@@ -131,7 +130,6 @@ class SentenceEntity(
       legacyData = sentence.legacyData,
       updatedAt = ZonedDateTime.now(),
       updatedBy = createdBy,
-      updatedPrison = sentence.prisonId,
       fineAmount = sentence.fine?.fineAmount,
     )
     return sentenceEntity
@@ -208,7 +206,6 @@ class SentenceEntity(
         EntityStatus.INACTIVE
       },
       createdBy = createdBy,
-      createdPrison = sentence.prisonId,
       supersedingSentence = null,
       charge = chargeEntity,
       sentenceServeType = if (consecutiveTo != null) "CONSECUTIVE" else "UNKNOWN",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/dto/LegacyCreatePeriodLength.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/dto/LegacyCreatePeriodLength.kt
@@ -11,6 +11,4 @@ data class LegacyCreatePeriodLength(
   val periodWeeks: Int?,
   val periodDays: Int?,
   val legacyData: PeriodLengthLegacyData,
-  @Schema(description = "Prison identifier where create/update originated from.", required = true, example = "MDI")
-  val prisonId: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/dto/LegacyCreateSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/dto/LegacyCreateSentence.kt
@@ -9,7 +9,6 @@ data class LegacyCreateSentence(
   val fine: LegacyCreateFine?,
   val consecutiveToLifetimeUuid: UUID?,
   val active: Boolean,
-  val prisonId: String,
   var legacyData: SentenceLegacyData,
   val returnToCustodyDate: LocalDate? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/util/DataCreator.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/util/DataCreator.kt
@@ -102,7 +102,6 @@ class DataCreator {
       fine: LegacyCreateFine = legacyCreateFine(),
       consecutiveToLifetimeUuid: UUID? = null,
       active: Boolean = true,
-      prisonId: String = "PRISON1",
       sentenceLegacyData: SentenceLegacyData = sentenceLegacyData(),
       returnToCustodyDate: LocalDate? = null,
     ): LegacyCreateSentence = LegacyCreateSentence(
@@ -111,7 +110,6 @@ class DataCreator {
       fine,
       consecutiveToLifetimeUuid,
       active,
-      prisonId,
       sentenceLegacyData,
       returnToCustodyDate,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/util/DataCreator.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/util/DataCreator.kt
@@ -231,7 +231,6 @@ class DataCreator {
       periodWeeks: Int? = null,
       periodDays: Int? = 2,
       legacyData: PeriodLengthLegacyData = periodLengthLegacyData(),
-      prisonId: String = "MDI",
     ): LegacyCreatePeriodLength = LegacyCreatePeriodLength(
       sentenceUUID,
       periodYears,
@@ -239,7 +238,6 @@ class DataCreator {
       periodWeeks,
       periodDays,
       legacyData,
-      prisonId,
     )
   }
 }


### PR DESCRIPTION
This is because the prisonId cannot be reliably sourced i this legacy scenario - currently they are just hardcoding it