### PR TITLE
RCLL-414: Adds endpoint to retrieve recallable court cases

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
@@ -142,7 +142,7 @@ class CourtCaseController(private val courtCaseService: CourtCaseService, privat
   @PreAuthorize("hasAnyRole('ROLE_REMAND_AND_SENTENCING__REMAND_AND_SENTENCING_UI', 'ROLE_REMAND_SENTENCING__RECORD_RECALL_RW')")
   @Operation(
     summary = "Retrieve recallable court cases for a prisoner",
-    description = "This endpoint returns filtered court cases optimized for recall processing workflows. Only includes ACTIVE cases with SENTENCING warrant type that have sentences.",
+    description = "This endpoint returns filtered court cases optimised for recall processing workflows. Only includes ACTIVE cases with SENTENCING warrant type that have sentences.",
   )
   @ApiResponses(
     value = [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
@@ -139,7 +139,7 @@ class CourtCaseController(private val courtCaseService: CourtCaseService, privat
   }
 
   @GetMapping("/court-case/{prisonerId}/recallable-court-cases")
-  @PreAuthorize("hasAnyRole('ROLE_REMAND_AND_SENTENCING__REMAND_AND_SENTENCING_UI', 'ROLE_REMAND_SENTENCING__RECORD_RECALL_RW')")
+  @PreAuthorize("hasAnyRole('ROLE_REMAND_SENTENCING__RECORD_RECALL_RW')")
   @Operation(
     summary = "Retrieve recallable court cases for a prisoner",
     description = "This endpoint returns filtered court cases optimised for recall processing workflows. Only includes ACTIVE cases with SENTENCING warrant type that have sentences.",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableCourtCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableCourtCase.kt
@@ -4,9 +4,9 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.EntityS
 import java.time.LocalDate
 
 data class RecallableCourtCase(
-  val caseId: String,
+  val courtCaseUuid: String,
   val reference: String,
-  val court: String,
+  val courtCode: String,
   val date: LocalDate,
   val status: EntityStatus,
   val isSentenced: Boolean,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableCourtCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableCourtCase.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.recall
+
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.EntityStatus
+import java.time.LocalDate
+
+data class RecallableCourtCase(
+  val caseId: String,
+  val reference: String,
+  val court: String,
+  val date: LocalDate,
+  val status: EntityStatus,
+  val isSentenced: Boolean,
+  val sentences: List<RecallableSentence>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableCourtCasesResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableCourtCasesResponse.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.recall
+
+data class RecallableCourtCasesResponse(
+  val totalCases: Int,
+  val cases: List<RecallableCourtCase>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableSentence.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.recall
+
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.PeriodLength
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.SentenceTypeClassification
+import java.time.LocalDate
+import java.util.UUID
+
+data class RecallableSentence(
+  val sentenceId: UUID,
+  val nomisSentenceId: NomisSentenceId?,
+  val offenceCode: String?,
+  val sentenceType: String?,
+  val classification: SentenceTypeClassification?,
+  val systemOfRecord: String,
+  val startDate: LocalDate?,
+  val periodLengths: List<PeriodLength>,
+  val convictionDate: LocalDate?,
+)
+
+data class NomisSentenceId(
+  val bookingId: Long,
+  val sentenceSequence: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/recall/RecallableSentence.kt
@@ -6,18 +6,11 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class RecallableSentence(
-  val sentenceId: UUID,
-  val nomisSentenceId: NomisSentenceId?,
+  val sentenceUuid: UUID,
   val offenceCode: String?,
   val sentenceType: String?,
   val classification: SentenceTypeClassification?,
   val systemOfRecord: String,
-  val startDate: LocalDate?,
   val periodLengths: List<PeriodLength>,
   val convictionDate: LocalDate?,
-)
-
-data class NomisSentenceId(
-  val bookingId: Long,
-  val sentenceSequence: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/CourtCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/CourtCaseService.kt
@@ -10,7 +10,12 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.C
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.CourtCaseCountNumbers
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.CourtCases
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.CreateCourtCase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.PeriodLength
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.paged.PagedCourtCase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.recall.NomisSentenceId
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.recall.RecallableCourtCase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.recall.RecallableCourtCasesResponse
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.recall.RecallableSentence
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventType
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.RecordResponse
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.util.EventMetadataCreator
@@ -129,6 +134,104 @@ class CourtCaseService(private val courtCaseRepository: CourtCaseRepository, pri
   fun getSentencedCourtCases(prisonerId: String): RecordResponse<CourtCases> = courtCaseRepository.findSentencedCourtCasesByPrisonerId(prisonerId).let {
     val eventsToEmit = fixManyChargesToSentenceService.fixCourtCaseSentences(it)
     RecordResponse(CourtCases.from(it), eventsToEmit)
+  }
+
+  @Transactional
+  fun getRecallableCourtCases(
+    prisonerId: String,
+    sortBy: String = "date",
+    sortOrder: String = "desc",
+  ): RecordResponse<RecallableCourtCasesResponse> {
+    val courtCases = courtCaseRepository.findSentencedCourtCasesByPrisonerId(prisonerId)
+      .filter { courtCase ->
+        courtCase.statusId == EntityStatus.ACTIVE &&
+          courtCase.latestCourtAppearance?.let { appearance ->
+            (appearance.warrantType == "SENTENCING" || appearance.warrantType == "SENTENCED") &&
+              appearance.appearanceCharges.any { appearanceCharge ->
+                appearanceCharge.charge?.statusId == EntityStatus.ACTIVE &&
+                  appearanceCharge.charge?.sentences?.any { sentence ->
+                    sentence.statusId == EntityStatus.ACTIVE
+                  } == true
+              }
+          } ?: false
+      }
+
+    val eventsToEmit = fixManyChargesToSentenceService.fixCourtCaseSentences(courtCases)
+
+    val recallableCourtCases = courtCases.map { courtCase ->
+      val latestAppearance = courtCase.latestCourtAppearance!!
+      RecallableCourtCase(
+        caseId = courtCase.caseUniqueIdentifier,
+        reference = latestAppearance.courtCaseReference ?: "",
+        court = latestAppearance.courtCode,
+        date = latestAppearance.appearanceDate,
+        status = courtCase.statusId,
+        isSentenced = latestAppearance.appearanceCharges.any { it.charge?.sentences?.isNotEmpty() == true },
+        sentences = latestAppearance.appearanceCharges
+          .filter { it.charge?.statusId == EntityStatus.ACTIVE }
+          .flatMap { it.charge?.sentences ?: emptyList() }
+          .filter { it.statusId == EntityStatus.ACTIVE }
+          .map { sentence ->
+            RecallableSentence(
+              sentenceId = sentence.sentenceUuid,
+              nomisSentenceId = sentence.legacyData?.nomisLineReference?.let { ref ->
+                val parts = ref.split("-")
+                if (parts.size >= 2) {
+                  NomisSentenceId(
+                    bookingId = parts[0].toLongOrNull() ?: 0L,
+                    sentenceSequence = parts[1].toIntOrNull() ?: 1,
+                  )
+                } else {
+                  null
+                }
+              },
+              offenceCode = sentence.charge.offenceCode,
+              sentenceType = sentence.sentenceType?.description,
+              classification = sentence.sentenceType?.classification,
+              systemOfRecord = "RAS",
+              startDate = sentence.convictionDate,
+              periodLengths = sentence.periodLengths.map { periodLength ->
+                PeriodLength(
+                  years = periodLength.years,
+                  months = periodLength.months,
+                  weeks = periodLength.weeks,
+                  days = periodLength.days,
+                  periodOrder = periodLength.periodOrder,
+                  periodLengthType = periodLength.periodLengthType,
+                  legacyData = periodLength.legacyData,
+                  periodLengthUuid = periodLength.periodLengthUuid,
+                )
+              },
+              convictionDate = sentence.convictionDate,
+            )
+          },
+      )
+    }
+
+    val sortedCases = when (sortBy.lowercase()) {
+      "reference" -> when (sortOrder.lowercase()) {
+        "asc" -> recallableCourtCases.sortedBy { it.reference }
+        else -> recallableCourtCases.sortedByDescending { it.reference }
+      }
+
+      "court" -> when (sortOrder.lowercase()) {
+        "asc" -> recallableCourtCases.sortedBy { it.court }
+        else -> recallableCourtCases.sortedByDescending { it.court }
+      }
+
+      else -> when (sortOrder.lowercase()) {
+        "asc" -> recallableCourtCases.sortedBy { it.date }
+        else -> recallableCourtCases.sortedByDescending { it.date }
+      }
+    }
+
+    return RecordResponse(
+      RecallableCourtCasesResponse(
+        totalCases = sortedCases.size,
+        cases = sortedCases,
+      ),
+      eventsToEmit,
+    )
   }
 
   @Transactional(readOnly = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/CourtCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/CourtCaseService.kt
@@ -146,7 +146,7 @@ class CourtCaseService(private val courtCaseRepository: CourtCaseRepository, pri
       .filter { courtCase ->
         courtCase.statusId == EntityStatus.ACTIVE &&
           courtCase.latestCourtAppearance?.let { appearance ->
-            (appearance.warrantType == "SENTENCING" || appearance.warrantType == "SENTENCED") &&
+            appearance.warrantType == "SENTENCING" &&
               appearance.appearanceCharges.any { appearanceCharge ->
                 appearanceCharge.charge?.statusId == EntityStatus.ACTIVE &&
                   appearanceCharge.charge?.sentences?.any { sentence ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/GetRecallableCourtCasesTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/GetRecallableCourtCasesTests.kt
@@ -1,0 +1,203 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.courtcase
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCreator
+import java.time.LocalDate
+import java.util.UUID
+
+class GetRecallableCourtCasesTests : IntegrationTestBase() {
+
+  @Test
+  fun `get all recallable court cases with sentenced status`() {
+    // Create a court case that should appear in recallable list
+    val sentencedCharge = DpsDataCreator.dpsCreateCharge(sentence = DpsDataCreator.dpsCreateSentence())
+    val sentencedAppearance = DpsDataCreator.dpsCreateCourtAppearance(
+      charges = listOf(sentencedCharge),
+      outcomeUuid = UUID.fromString("315280e5-d53e-43b3-8ba6-44da25676ce2"), // Sentenced outcome
+      warrantType = "SENTENCING"
+    )
+    val sentencedCourtCase = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(sentencedAppearance))
+    val (sentencedCourtCaseUuid, createdSentencedCase) = createCourtCase(sentencedCourtCase)
+
+    // Create a remanded court case (should NOT appear in recallable list - no sentence)
+    val remandedCharge = DpsDataCreator.dpsCreateCharge(sentence = null, outcomeUuid = UUID.fromString("315280e5-d53e-43b3-8ba6-44da25676ce2"))
+    val remandedAppearance = DpsDataCreator.dpsCreateCourtAppearance(
+      charges = listOf(remandedCharge), 
+      outcomeUuid = UUID.fromString("2f585681-7b1a-44fb-a0cb-f9a4b1d9cda8"), // Remanded outcome
+      warrantType = "REMAND"
+    )
+    val remandedCourtCase = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(remandedAppearance))
+    val (remandedCourtCaseUuid) = createCourtCase(remandedCourtCase)
+
+    webTestClient
+      .get()
+      .uri("/court-case/${createdSentencedCase.prisonerId}/recallable-court-cases")
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING__REMAND_AND_SENTENCING_UI"))
+      }
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("$.totalCases").isEqualTo(1)
+      .jsonPath("$.cases.length()").isEqualTo(1)
+      .jsonPath("$.cases[0].caseId").isEqualTo(sentencedCourtCaseUuid)
+      .jsonPath("$.cases[0].isSentenced").isEqualTo(true)
+      .jsonPath("$.cases[0].sentences.length()").isEqualTo(1)
+      .jsonPath("$.cases[0].sentences[0].sentenceId").exists()
+      .jsonPath("$.cases[0].sentences[0].offenceCode").exists()
+      .jsonPath("$.cases[0].sentences[0].sentenceType").exists()
+  }
+
+  @Test
+  fun `get recallable court cases with sorting by date descending`() {
+    val charge1 = DpsDataCreator.dpsCreateCharge(sentence = DpsDataCreator.dpsCreateSentence())
+    val appearance1 = DpsDataCreator.dpsCreateCourtAppearance(
+      charges = listOf(charge1),
+      warrantType = "SENTENCING",
+      appearanceDate = LocalDate.of(2024, 1, 15)
+    )
+    val courtCase1 = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance1))
+    val (courtCaseUuid1, createdCase1) = createCourtCase(courtCase1)
+
+    val charge2 = DpsDataCreator.dpsCreateCharge(sentence = DpsDataCreator.dpsCreateSentence())
+    val appearance2 = DpsDataCreator.dpsCreateCourtAppearance(
+      charges = listOf(charge2),
+      warrantType = "SENTENCING",
+      appearanceDate = LocalDate.of(2024, 1, 10)
+    )
+    val courtCase2 = DpsDataCreator.dpsCreateCourtCase(
+      appearances = listOf(appearance2),
+      prisonerId = createdCase1.prisonerId // Same prisoner
+    )
+    val (courtCaseUuid2) = createCourtCase(courtCase2)
+
+    webTestClient
+      .get()
+      .uri("/court-case/${createdCase1.prisonerId}/recallable-court-cases?sortBy=date&sortOrder=desc")
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING__REMAND_AND_SENTENCING_UI"))
+      }
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("$.totalCases").isEqualTo(2)
+      .jsonPath("$.cases.length()").isEqualTo(2)
+      .jsonPath("$.cases[0].caseId").isEqualTo(courtCaseUuid1) // More recent date first
+      .jsonPath("$.cases[1].caseId").isEqualTo(courtCaseUuid2)
+  }
+
+  @Test
+  fun `get recallable court cases with sorting by date ascending`() {
+    val charge1 = DpsDataCreator.dpsCreateCharge(sentence = DpsDataCreator.dpsCreateSentence())
+    val appearance1 = DpsDataCreator.dpsCreateCourtAppearance(
+      charges = listOf(charge1),
+      warrantType = "SENTENCING",
+      appearanceDate = LocalDate.of(2024, 1, 15)
+    )
+    val courtCase1 = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance1))
+    val (courtCaseUuid1, createdCase1) = createCourtCase(courtCase1)
+
+    val charge2 = DpsDataCreator.dpsCreateCharge(sentence = DpsDataCreator.dpsCreateSentence())
+    val appearance2 = DpsDataCreator.dpsCreateCourtAppearance(
+      charges = listOf(charge2),
+      warrantType = "SENTENCING",
+      appearanceDate = LocalDate.of(2024, 1, 10)
+    )
+    val courtCase2 = DpsDataCreator.dpsCreateCourtCase(
+      appearances = listOf(appearance2),
+      prisonerId = createdCase1.prisonerId // Same prisoner
+    )
+    val (courtCaseUuid2) = createCourtCase(courtCase2)
+
+    webTestClient
+      .get()
+      .uri("/court-case/${createdCase1.prisonerId}/recallable-court-cases?sortBy=date&sortOrder=asc")
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING__REMAND_AND_SENTENCING_UI"))
+      }
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("$.totalCases").isEqualTo(2)
+      .jsonPath("$.cases.length()").isEqualTo(2)
+      .jsonPath("$.cases[0].caseId").isEqualTo(courtCaseUuid2) // Earlier date first
+      .jsonPath("$.cases[1].caseId").isEqualTo(courtCaseUuid1)
+  }
+
+  @Test
+  fun `get recallable court cases with alternative authorized role`() {
+    val charge = DpsDataCreator.dpsCreateCharge(sentence = DpsDataCreator.dpsCreateSentence())
+    val appearance = DpsDataCreator.dpsCreateCourtAppearance(
+      charges = listOf(charge),
+      warrantType = "SENTENCING"
+    )
+    val courtCase = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance))
+    val (_, createdCase) = createCourtCase(courtCase)
+
+    webTestClient
+      .get()
+      .uri("/court-case/${createdCase.prisonerId}/recallable-court-cases")
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_SENTENCING__RECORD_RECALL_RW"))
+      }
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("$.totalCases").isEqualTo(1)
+      .jsonPath("$.cases.length()").isEqualTo(1)
+  }
+
+  @Test
+  fun `returns empty list when no recallable court cases exist for prisoner`() {
+    val charge = DpsDataCreator.dpsCreateCharge(sentence = null) // No sentence
+    val appearance = DpsDataCreator.dpsCreateCourtAppearance(
+      charges = listOf(charge),
+      warrantType = "REMAND" // Not sentenced
+    )
+    val courtCase = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance))
+    val (_, createdCase) = createCourtCase(courtCase)
+
+    webTestClient
+      .get()
+      .uri("/court-case/${createdCase.prisonerId}/recallable-court-cases")
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING__REMAND_AND_SENTENCING_UI"))
+      }
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("$.totalCases").isEqualTo(0)
+      .jsonPath("$.cases.length()").isEqualTo(0)
+  }
+
+  @Test
+  fun `no token results in unauthorized`() {
+    webTestClient.get()
+      .uri("/court-case/ABC123/recallable-court-cases")
+      .headers {
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `token with incorrect role is forbidden`() {
+    webTestClient.get()
+      .uri("/court-case/ABC123/recallable-court-cases")
+      .headers {
+        it.authToken(roles = listOf("ROLE_OTHER_FUNCTION"))
+      }
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/GetRecallableCourtCasesTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/GetRecallableCourtCasesTests.kt
@@ -16,7 +16,7 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     val sentencedAppearance = DpsDataCreator.dpsCreateCourtAppearance(
       charges = listOf(sentencedCharge),
       outcomeUuid = UUID.fromString("315280e5-d53e-43b3-8ba6-44da25676ce2"), // Sentenced outcome
-      warrantType = "SENTENCING"
+      warrantType = "SENTENCING",
     )
     val sentencedCourtCase = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(sentencedAppearance))
     val (sentencedCourtCaseUuid, createdSentencedCase) = createCourtCase(sentencedCourtCase)
@@ -24,12 +24,12 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     // Create a remanded court case (should NOT appear in recallable list - no sentence)
     val remandedCharge = DpsDataCreator.dpsCreateCharge(sentence = null, outcomeUuid = UUID.fromString("315280e5-d53e-43b3-8ba6-44da25676ce2"))
     val remandedAppearance = DpsDataCreator.dpsCreateCourtAppearance(
-      charges = listOf(remandedCharge), 
+      charges = listOf(remandedCharge),
       outcomeUuid = UUID.fromString("2f585681-7b1a-44fb-a0cb-f9a4b1d9cda8"), // Remanded outcome
-      warrantType = "REMAND"
+      warrantType = "REMAND",
     )
     val remandedCourtCase = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(remandedAppearance))
-    val (remandedCourtCaseUuid) = createCourtCase(remandedCourtCase)
+    createCourtCase(remandedCourtCase)
 
     webTestClient
       .get()
@@ -57,7 +57,7 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     val appearance1 = DpsDataCreator.dpsCreateCourtAppearance(
       charges = listOf(charge1),
       warrantType = "SENTENCING",
-      appearanceDate = LocalDate.of(2024, 1, 15)
+      appearanceDate = LocalDate.of(2024, 1, 15),
     )
     val courtCase1 = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance1))
     val (courtCaseUuid1, createdCase1) = createCourtCase(courtCase1)
@@ -66,11 +66,11 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     val appearance2 = DpsDataCreator.dpsCreateCourtAppearance(
       charges = listOf(charge2),
       warrantType = "SENTENCING",
-      appearanceDate = LocalDate.of(2024, 1, 10)
+      appearanceDate = LocalDate.of(2024, 1, 10),
     )
     val courtCase2 = DpsDataCreator.dpsCreateCourtCase(
       appearances = listOf(appearance2),
-      prisonerId = createdCase1.prisonerId // Same prisoner
+      prisonerId = createdCase1.prisonerId, // Same prisoner
     )
     val (courtCaseUuid2) = createCourtCase(courtCase2)
 
@@ -96,7 +96,7 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     val appearance1 = DpsDataCreator.dpsCreateCourtAppearance(
       charges = listOf(charge1),
       warrantType = "SENTENCING",
-      appearanceDate = LocalDate.of(2024, 1, 15)
+      appearanceDate = LocalDate.of(2024, 1, 15),
     )
     val courtCase1 = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance1))
     val (courtCaseUuid1, createdCase1) = createCourtCase(courtCase1)
@@ -105,11 +105,11 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     val appearance2 = DpsDataCreator.dpsCreateCourtAppearance(
       charges = listOf(charge2),
       warrantType = "SENTENCING",
-      appearanceDate = LocalDate.of(2024, 1, 10)
+      appearanceDate = LocalDate.of(2024, 1, 10),
     )
     val courtCase2 = DpsDataCreator.dpsCreateCourtCase(
       appearances = listOf(appearance2),
-      prisonerId = createdCase1.prisonerId // Same prisoner
+      prisonerId = createdCase1.prisonerId, // Same prisoner
     )
     val (courtCaseUuid2) = createCourtCase(courtCase2)
 
@@ -134,7 +134,7 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     val charge = DpsDataCreator.dpsCreateCharge(sentence = DpsDataCreator.dpsCreateSentence())
     val appearance = DpsDataCreator.dpsCreateCourtAppearance(
       charges = listOf(charge),
-      warrantType = "SENTENCING"
+      warrantType = "SENTENCING",
     )
     val courtCase = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance))
     val (_, createdCase) = createCourtCase(courtCase)
@@ -158,7 +158,7 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     val charge = DpsDataCreator.dpsCreateCharge(sentence = null) // No sentence
     val appearance = DpsDataCreator.dpsCreateCourtAppearance(
       charges = listOf(charge),
-      warrantType = "REMAND" // Not sentenced
+      warrantType = "REMAND", // Not sentenced
     )
     val courtCase = DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance))
     val (_, createdCase) = createCourtCase(courtCase)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/GetRecallableCourtCasesTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/GetRecallableCourtCasesTests.kt
@@ -202,13 +202,13 @@ class GetRecallableCourtCasesTests : IntegrationTestBase() {
     val newerChargeWithoutSentence = DpsDataCreator.dpsCreateCharge(sentence = null)
     val newerAppearance = DpsDataCreator.dpsCreateCourtAppearance(
       charges = listOf(newerChargeWithoutSentence),
-      warrantType = "SENTENCING", 
+      warrantType = "SENTENCING",
       appearanceDate = LocalDate.of(2024, 1, 15),
     )
 
     // Court case has both appearances - latest has no sentence, older has sentence
     val courtCase = DpsDataCreator.dpsCreateCourtCase(
-      appearances = listOf(olderAppearance, newerAppearance)
+      appearances = listOf(olderAppearance, newerAppearance),
     )
     val (courtCaseUuid, createdCase) = createCourtCase(courtCase)
 


### PR DESCRIPTION
Implements a new endpoint to retrieve a filtered list of court cases suitable for recall processing. The endpoint filters for ACTIVE cases with SENTENCING warrant types that have associated sentences. The court cases can be sorted by date, reference, or court.