### PR TITLE
RASS-1996 Update immigration detention create flow to make immigration court cases INACTIVE if no-longer-of-interest outcome

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/repository/CourtCaseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/repository/CourtCaseRepository.kt
@@ -82,6 +82,8 @@ interface CourtCaseRepository :
 
   fun findAllByPrisonerId(prisonerId: String): List<CourtCaseEntity>
 
+  fun findAllByPrisonerIdAndStatusId(prisonerId: String, statusId: CourtCaseEntityStatus = CourtCaseEntityStatus.ACTIVE): List<CourtCaseEntity>
+
   fun findAllByPrisonerIdAndStatusIdNot(prisonerId: String, statusId: CourtCaseEntityStatus = CourtCaseEntityStatus.DELETED): List<CourtCaseEntity>
 
   fun findAllByPrisonerIdInAndStatusIdNot(prisonerIds: List<String>, statusId: CourtCaseEntityStatus = CourtCaseEntityStatus.DELETED): List<CourtCaseEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/ImmigrationDetentionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/ImmigrationDetentionService.kt
@@ -303,9 +303,9 @@ class ImmigrationDetentionService(
       courtCase.updatedBy = immigrationDetention.createdByUsername
       eventsToEmit.add(
         EventMetadataCreator.courtCaseEventMetadata(
-          courtCase.prisonerId,
-          courtCase.caseUniqueIdentifier,
-          EventType.COURT_CASE_UPDATED,
+          prisonerId = courtCase.prisonerId,
+          courtCaseId = courtCase.caseUniqueIdentifier,
+          eventType = EventType.COURT_CASE_UPDATED,
         ),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/ImmigrationDetentionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/ImmigrationDetentionService.kt
@@ -18,8 +18,11 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.Court
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.ImmigrationDetentionEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.audit.ImmigrationDetentionHistoryEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtAppearanceEntityStatus
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtCaseEntityStatus.INACTIVE
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionEntityStatus.ACTIVE
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionRecordType.NO_LONGER_OF_INTEREST
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.CourtAppearanceRepository
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.CourtCaseRepository
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.ImmigrationDetentionRepository
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.audit.ImmigrationDetentionHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.legacy.CourtCaseReferenceService
@@ -34,6 +37,7 @@ class ImmigrationDetentionService(
   private val courtAppearanceService: CourtAppearanceService,
   private val chargeOutcomeService: ChargeOutcomeService,
   private val appearanceOutcomeService: AppearanceOutcomeService,
+  private val courtCaseRepository: CourtCaseRepository,
   private val courtAppearanceRepository: CourtAppearanceRepository,
   private val courtCaseReferenceService: CourtCaseReferenceService,
   private val serviceUserService: ServiceUserService,
@@ -60,6 +64,9 @@ class ImmigrationDetentionService(
           legacyData = null,
         ),
       )
+      if (immigrationDetention.immigrationDetentionRecordType == NO_LONGER_OF_INTEREST) {
+        createdCourtCase.statusId = INACTIVE
+      }
       eventsToEmit.addAll(events)
 
       courtAppearanceService.createCourtAppearance(
@@ -91,6 +98,8 @@ class ImmigrationDetentionService(
         courtAppearanceEntity?.appearanceUuid,
       ),
     )
+    val courtCaseUpdatedEvents = deactivateImmigrationCourtCases(immigrationDetention)
+    eventsToEmit.addAll(courtCaseUpdatedEvents)
 
     return RecordResponse(
       SaveImmigrationDetentionResponse.from(savedImmigrationDetention),
@@ -107,6 +116,7 @@ class ImmigrationDetentionService(
       immigrationDetentionRepository.findOneByImmigrationDetentionUuid(immigrationDetentionUuid)
 
     return if (immigrationDetentionToUpdate == null) {
+      // This create-via-update flow is only applicable when we update an existing NOMIS immigration appearance via DPS
       createImmigrationDetention(immigrationDetention, immigrationDetentionUuid)
     } else {
       immigrationDetentionHistoryRepository.save(
@@ -277,5 +287,28 @@ class ImmigrationDetentionService(
 
   fun findByAppearanceUuidAndMap(appearanceUuid: UUID): ImmigrationDetention? = courtAppearanceRepository.findByAppearanceUuid(appearanceUuid)?.takeUnless { it.statusId == CourtAppearanceEntityStatus.DELETED }?.let {
     ImmigrationDetention.fromCourtAppearance(it, it.courtCase.prisonerId)
+  }
+
+  private fun deactivateImmigrationCourtCases(immigrationDetention: CreateImmigrationDetention): Set<EventMetadata> {
+    if (immigrationDetention.immigrationDetentionRecordType != NO_LONGER_OF_INTEREST) return emptySet()
+
+    val eventsToEmit = mutableSetOf<EventMetadata>()
+    val activeImmigrationCases = courtCaseRepository.findAllByPrisonerIdAndStatusId(immigrationDetention.prisonerId)
+      .filter { courtCase ->
+        courtCase.appearances.all { it.statusId == CourtAppearanceEntityStatus.IMMIGRATION_APPEARANCE }
+      }
+    activeImmigrationCases.forEach { courtCase ->
+      courtCase.statusId = INACTIVE
+      courtCase.updatedAt = ZonedDateTime.now()
+      courtCase.updatedBy = immigrationDetention.createdByUsername
+      eventsToEmit.add(
+        EventMetadataCreator.courtCaseEventMetadata(
+          courtCase.prisonerId,
+          courtCase.caseUniqueIdentifier,
+          EventType.COURT_CASE_UPDATED,
+        ),
+      )
+    }
+    return eventsToEmit
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/immigrationdetention/CreateImmigrationDetentionTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/immigrationdetention/CreateImmigrationDetentionTests.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.ImmigrationDetention
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtAppearanceEntityStatus.IMMIGRATION_APPEARANCE
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtCaseEntityStatus.INACTIVE
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionRecordType.IS91
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionRecordType.NO_LONGER_OF_INTEREST
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCreator
@@ -60,10 +61,10 @@ class CreateImmigrationDetentionTests : IntegrationTestBase() {
 
     createImmigrationDetention(immigrationDetention2)
 
-    messages = getMessages(3)
+    messages = getMessages(4)
 
-    assertThat(messages).hasSize(3).extracting<String> { it.eventType }
-      .contains("court-appearance.inserted", "charge.inserted", "court-case.inserted")
+    assertThat(messages).hasSize(4).extracting<String> { it.eventType }
+      .contains("court-appearance.inserted", "charge.inserted", "court-case.inserted", "court-case.updated")
 
     val courtAppearances = courtAppearanceRepository.findAllByCourtCasePrisonerIdAndStatusId("A12345B", IMMIGRATION_APPEARANCE)
 
@@ -109,5 +110,67 @@ class CreateImmigrationDetentionTests : IntegrationTestBase() {
 
     assertThat(messages).hasSize(2).extracting<String> { it.eventType }
       .contains("court-appearance.updated", "charge.updated")
+  }
+
+  @Test
+  fun `create no-longer-of-interest outcome deactivates linked immigration court case`() {
+    val courtAppearanceUuid = createNomisImmigrationDetentionCourtCase(prisonerId = "B12345B", "5500")
+    val noLongerOfInterest = DpsDataCreator.dpsCreateImmigrationDetention(
+      prisonerId = "B12345B",
+      immigrationDetentionRecordType = NO_LONGER_OF_INTEREST,
+      recordDate = LocalDate.of(2021, 1, 1),
+      createdByUsername = "aUser",
+      createdByPrison = "PRI",
+      appearanceOutcomeUuid = IMMIGRATION_NO_LONGER_OF_INTEREST_UUID,
+      courtAppearanceUuid = courtAppearanceUuid,
+    )
+
+    createImmigrationDetention(noLongerOfInterest)
+
+    val courtAppearance = courtAppearanceRepository.findByAppearanceUuid(courtAppearanceUuid)!!
+    val courtCase = courtCaseRepository.findByCaseUniqueIdentifier(courtAppearance.courtCase.caseUniqueIdentifier)!!
+    assertThat(courtCase.statusId).isEqualTo(INACTIVE)
+
+    val messages = getMessages(3)
+    assertThat(messages).extracting<String> { it.eventType }
+      .contains("court-case.updated")
+      .doesNotContain("court-case.inserted")
+  }
+
+  @Test
+  fun `create no-longer-of-interest from DPS with no existing court-case, creates INACTIVE court-case`() {
+    val noLongerOfInterest = DpsDataCreator.dpsCreateImmigrationDetention(
+      prisonerId = "C12345D",
+      immigrationDetentionRecordType = NO_LONGER_OF_INTEREST,
+      recordDate = LocalDate.of(2021, 3, 1),
+      createdByUsername = "aUser",
+      createdByPrison = "PRI",
+      appearanceOutcomeUuid = IMMIGRATION_NO_LONGER_OF_INTEREST_UUID,
+    )
+
+    val response = createImmigrationDetention(noLongerOfInterest)
+    val createdRecord = getImmigrationDetentionByUUID(response.immigrationDetentionUuid)
+
+    assertThat(createdRecord).usingRecursiveComparison()
+      .ignoringFields("createdAt")
+      .isEqualTo(
+        ImmigrationDetention(
+          immigrationDetentionUuid = response.immigrationDetentionUuid,
+          courtAppearanceUuid = response.courtAppearanceUuid!!,
+          prisonerId = "C12345D",
+          immigrationDetentionRecordType = NO_LONGER_OF_INTEREST,
+          recordDate = LocalDate.of(2021, 3, 1),
+          createdAt = ZonedDateTime.now(),
+        ),
+      )
+
+    val courtAppearance = courtAppearanceRepository.findByAppearanceUuid(response.courtAppearanceUuid)!!
+    val courtCase = courtCaseRepository.findByCaseUniqueIdentifier(courtAppearance.courtCase.caseUniqueIdentifier)!!
+    assertThat(courtCase.statusId).isEqualTo(INACTIVE)
+
+    val messages = getMessages(3)
+    assertThat(messages).extracting<String> { it.eventType }
+      .contains("court-case.inserted")
+      .doesNotContain("court-case.updated")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/immigrationdetention/DeleteImmigrationTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/immigrationdetention/DeleteImmigrationTests.kt
@@ -32,10 +32,10 @@ class DeleteImmigrationTests : IntegrationTestBase() {
     val id1Response = createImmigrationDetention(id1)
     val id2Response = createImmigrationDetention(id2)
 
-    var messages = getMessages(6)
+    var messages = getMessages(7)
 
-    assertThat(messages).hasSize(6).extracting<String> { it.eventType }
-      .contains("court-case.inserted", "court-case.inserted", "court-appearance.inserted", "charge.inserted", "court-appearance.inserted", "charge.inserted")
+    assertThat(messages).hasSize(7).extracting<String> { it.eventType }
+      .contains("court-case.inserted", "court-case.inserted", "court-appearance.inserted", "charge.inserted", "court-appearance.inserted", "charge.inserted", "court-case.updated")
 
     purgeQueues()
 


### PR DESCRIPTION
TODO
- check with analyst if a immigration outcome of NO_LONGER_OF_INTERST comes from the NOMIS sync if we should be setting the cases to inactive too. If we do, that will be a separate piece of work with a spike