### PR TITLE
Adjusted DTOs naming of Charge.kt and CourtCase.kt

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/subjectaccessrequest/alldata/Charge.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/subjectaccessrequest/alldata/Charge.kt
@@ -29,6 +29,5 @@ data class Charge(
   val offenceEndDate: LocalDate?,
   @param:JsonSerialize(using = StringSerializer::class, nullsUsing = StringNullSerializer::class)
   val chargeOutcome: String?,
-  val activeSentence: Sentence?,
-  val otherSentences: List<Sentence>?,
+  val liveSentence: Sentence?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/subjectaccessrequest/alldata/CourtCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/subjectaccessrequest/alldata/CourtCase.kt
@@ -19,5 +19,5 @@ data class CourtCase(
   @param:JsonSerialize(nullsUsing = ZonedDateTimeNullSerializer::class)
   val updatedAt: ZonedDateTime?,
   val latestCourtAppearance: CourtAppearance?,
-  val otherCourtAppearances: List<CourtAppearance>?,
+  val appearances: List<CourtAppearance>?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/subjectaccessrequest/alldata/util/ExpectResponseData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/subjectaccessrequest/alldata/util/ExpectResponseData.kt
@@ -15,6 +15,7 @@ object ExpectResponseData {
                 "caseStatus": "ACTIVE",
                 "createdAt": "2026-02-03 10:02",
                 "updatedAt": "2026-02-03 10:02",
+                "appearances": [],
                 "latestCourtAppearance": {
                   "appearanceDate": "2026-02-03",
                   "appearanceOutcomeName": "Imprisonment",
@@ -31,7 +32,7 @@ object ExpectResponseData {
                       "offenceStartDate": "1997-01-01",
                       "offenceEndDate": "No Data Held",
                       "chargeOutcome": "Imprisonment",
-                      "activeSentence": {
+                      "liveSentence": {
                           "sentenceTypeDescription": "ORA Breach Top Up Supervision",
                           "sentenceTypeClassification": "BOTUS",
                           "periodLengths": [
@@ -44,8 +45,7 @@ object ExpectResponseData {
                             }
                           ],
                           "sentenceServeType": "CONCURRENT"
-                      },
-                      "otherSentences" : []
+                      }
                     }
                   ]
                 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/subjectaccessrequest/alldata/util/PrisonerTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/subjectaccessrequest/alldata/util/PrisonerTestData.kt
@@ -33,7 +33,7 @@ object PrisonerTestData {
     createdAt = zoned("2026-02-03T10:02"),
     updatedAt = zoned("2026-02-03T10:02"),
     latestCourtAppearance = courtAppearance(),
-    otherCourtAppearances = listOf(),
+    appearances = listOf(),
   )
 
   fun courtAppearance() = CourtAppearance(
@@ -54,8 +54,7 @@ object PrisonerTestData {
     offenceStartDate = LocalDate.parse("1997-01-01"),
     offenceEndDate = null,
     chargeOutcome = "Imprisonment",
-    activeSentence = sentence(),
-    otherSentences = listOf(),
+    liveSentence = sentence(),
   )
 
   fun sentence() = Sentence(


### PR DESCRIPTION
The SAR will not included deleted data. Adjusting naming to better reflect the underlying entity naming.

Linked to merge
https://github.com/ministryofjustice/hmpps-remand-and-sentencing-api/pull/1025