### PR TITLE
Additional Comment to describe how to regenerate the entity-schema-snapshot.json contract

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/subjectaccessrequest/SarEntityComparisonIntegrationTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/subjectaccessrequest/SarEntityComparisonIntegrationTests.kt
@@ -15,6 +15,14 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequest.SarJpaEntitiesTest
  *
  * This test will likely need to be updated regularly as the Entity Model changes,
  * but is purposefully designed to help identify whether this change should be included in the SAR model.
+ *
+ * To regenerate the entity-schema-snapshot.json at any time run below and copy the output of
+ * src/test/resources/entity-schema.json.log to src/test/resources/sar/entity-schema-snapshot.json.
+ *
+ *  ```bash
+ * SAR_GENERATE_ACTUAL=true ./gradlew test \
+ *  --tests "uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.subjectaccessrequest.SarEntityComparisonIntegrationTests"
+ *  ```
  */
 @Import(SarIntegrationTestHelperConfig::class)
 @TestPropertySource(


### PR DESCRIPTION
Changes to the Entity Model will now cause a specific test to fail if the entity-schema-snapshot.json has not been updated to reflect this.

It's important to review the change and determine if it is needed in the SAR also. This test was designed by the SAR team to catch these cases.

> Note: The test is already in place, including additional comments to more easily recreate the json schema