### PR TITLE
RASS-2253 Include DUPLICATE recalls in earliest and latest recall  lookup 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/SentenceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/entity/SentenceEntity.kt
@@ -235,8 +235,8 @@ class SentenceEntity(
     statusId == other.statusId &&
     ((legacyData == null && other.legacyData == null) || legacyData?.isSame(other.legacyData) == true)
 
-  fun latestRecall(): RecallEntity? = recallSentences.map { it.recall }.filter { it.status == RecallEntityStatus.ACTIVE }.maxByOrNull { it.createdAt }
-  fun earliestRecall(): RecallEntity? = recallSentences.map { it.recall }.filter { it.status == RecallEntityStatus.ACTIVE }.minByOrNull { it.createdAt }
+  fun latestRecall(): RecallEntity? = recallSentences.map { it.recall }.filter { it.status != RecallEntityStatus.DELETED }.maxByOrNull { it.createdAt }
+  fun earliestRecall(): RecallEntity? = recallSentences.map { it.recall }.filter { it.status != RecallEntityStatus.DELETED }.minByOrNull { it.createdAt }
 
   fun copyFrom(sentence: CreateSentence, createdBy: String, chargeEntity: ChargeEntity, consecutiveTo: SentenceEntity?, sentenceType: SentenceTypeEntity?): SentenceEntity {
     val sentenceEntity = SentenceEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/RecallService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/RecallService.kt
@@ -505,10 +505,10 @@ class RecallService(
     sentence: SentenceEntity,
     recallType: RecallType,
   ): IsRecallPossible {
-    val latestRecall = sentence.earliestRecall()!!
+    val earliestRecall = sentence.earliestRecall()!!
 
     val recallLegacyData =
-      latestRecall.let { recall -> sentence.recallSentences.find { it.recall.id == recall.id }?.legacyData }!!
+      earliestRecall.let { recall -> sentence.recallSentences.find { it.recall.id == recall.id }?.legacyData }!!
     val sentenceCalcType = recallLegacyData.sentenceCalcType
 
     val classification =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/sentence/LegacyGetSentenceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/sentence/LegacyGetSentenceTests.kt
@@ -1,8 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.sentence
 
 import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.BookingDataCreator
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.DataCreator
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.booking.BookingCreateCourtCasesResponse
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCreator
 import java.time.LocalDate
 import java.util.UUID
@@ -63,6 +67,58 @@ class LegacyGetSentenceTests : IntegrationTestBase() {
       .isEqualTo("2020")
       .jsonPath("$.returnToCustodyDate")
       .isEqualTo("2024-01-01")
+  }
+
+  @Test
+  fun `get legacy sentence returns sentenceCalcType from DUPLICATE recall created via booking sync`() {
+    val recalledSentence = BookingDataCreator.bookingCreateSentence(
+      legacyData = DataCreator.sentenceLegacyData(sentenceCalcType = "HDR_ORA", sentenceCategory = "2003"),
+      returnToCustodyDate = LocalDate.of(2024, 1, 1),
+    )
+    val appearance = BookingDataCreator.bookingCreateCourtAppearance(
+      legacyData = DataCreator.courtAppearanceLegacyData(
+        outcomeConvictionFlag = true,
+        outcomeDispositionCode = "F",
+        nomisOutcomeCode = "1501",
+      ),
+      charges = listOf(BookingDataCreator.bookingCreateCharge(sentence = recalledSentence)),
+    )
+    val bookingCourtCases = BookingDataCreator.bookingCreateCourtCases(
+      courtCases = listOf(BookingDataCreator.bookingCreateCourtCase(appearances = listOf(appearance))),
+    )
+
+    val response = webTestClient
+      .post()
+      .uri("/legacy/court-case/booking")
+      .bodyValue(bookingCourtCases)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_COURT_CASE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus()
+      .isCreated
+      .returnResult<BookingCreateCourtCasesResponse>()
+      .responseBody.blockFirst()!!
+
+    val sentenceUuid = response.sentences.first().sentenceUuid
+
+    webTestClient
+      .get()
+      .uri("/legacy/sentence/$sentenceUuid")
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_SENTENCE_RO"))
+      }
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("$.lifetimeUuid")
+      .isEqualTo(sentenceUuid.toString())
+      .jsonPath("$.sentenceCalcType")
+      .isEqualTo("HDR_ORA")
+      .jsonPath("$.sentenceCategory")
+      .isEqualTo("2003")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceServiceTests.kt
@@ -476,6 +476,41 @@ class LegacySentenceServiceTests {
       assertThat(result.first).isEqualTo("14FTR_ORA")
       assertThat(result.second).isEqualTo("2020")
     }
+
+    @Test
+    fun `DUPLICATE recall with recall sentence legacy data returns sentenceCalcType and category from recall`() {
+      val (sentence, recall) = getSentenceAndRecall(
+        sentenceUuid = UUID.randomUUID(),
+        chargeUuid = UUID.randomUUID(),
+        appearanceUuid = UUID.randomUUID(),
+        recallType = RecallType.LR,
+        existingRtc = LocalDate.of(2024, 1, 11),
+      )
+      recall.status = RecallEntityStatus.DUPLICATE
+      sentence.sentenceType = recallBucketType()
+      sentence.legacyData = SentenceLegacyData(
+        sentenceCalcType = null,
+        sentenceCategory = null,
+        sentenceTypeDesc = null,
+        postedDate = "2024-01-01T00:00:00",
+        active = true,
+        nomisLineReference = null,
+        bookingId = null,
+      )
+      val recallSentence = sentence.recallSentences.single()
+      recallSentence.legacyData = RecallSentenceLegacyData(
+        sentenceCalcType = "HDR_ORA",
+        sentenceCategory = "2003",
+        sentenceTypeDesc = null,
+        postedDate = "2024-01-01T00:00:00",
+        active = true,
+      )
+
+      val result = LegacySentence.getSentenceCalcTypeAndCategory(sentence, sentence.latestRecall())
+
+      assertThat(result.first).isEqualTo("HDR_ORA")
+      assertThat(result.second).isEqualTo("2003")
+    }
   }
 
   private companion object {


### PR DESCRIPTION
the earliest and latest recall lookups from a sentence  Recalls were only considering ACTIVE recalls. We now consider any recall that isn’t DELETED, (which basically means we consider DUPLICATE and ACTIVE now  legacy sync patterns.

Primary impact: legacy sentence routes

Secondary impact: DPS is-recall-possible  (that uses `earliestRecall`)