### PR TITLE
Rass 1782 rest only

### DIFF
--- a/helm_deploy/hmpps-remand-and-sentencing-api/templates/cronjob-many-charges-to-sentence-fix.yaml
+++ b/helm_deploy/hmpps-remand-and-sentencing-api/templates/cronjob-many-charges-to-sentence-fix.yaml
@@ -25,7 +25,7 @@ spec:
               imagePullPolicy: IfNotPresent
               command: [ "/bin/sh", "-c" ]
               args:
-                - curl -XPOST --connect-timeout 5 --max-time 60 http://{{ include "generic-service.fullname" . }}/court-case-admin/cleanup-many-charges-to-sentence
+                - curl -XPOST --connect-timeout 5 --max-time 10 http://{{ include "generic-service.fullname" . }}/court-case-admin/cleanup-many-charges-to-sentence
               securityContext:
                 {{- toYaml .Values.manyChargesToSentenceFixCronjob.securityContext | nindent 16 }}
   {{- end }}

--- a/helm_deploy/hmpps-remand-and-sentencing-api/templates/cronjob-many-charges-to-sentence-fix.yaml
+++ b/helm_deploy/hmpps-remand-and-sentencing-api/templates/cronjob-many-charges-to-sentence-fix.yaml
@@ -1,0 +1,31 @@
+  {{- if .Values.manyChargesToSentenceFixCronjob.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "generic-service.fullname" . | trunc 27 }}-many-charges-fix
+  labels:
+    {{- include "generic-service.labels" . | nindent 4 }}
+
+spec:
+  schedule: "{{ .Values.manyChargesToSentenceFixCronjob.schedule }}"
+  timeZone: "{{ .Values.manyChargesToSentenceFixCronjob.timeZone }}"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 0 # Ensure the job controller does not retry if the pod fails
+      template:
+        spec:
+          restartPolicy: Never # Ensure the kubelet does not restart the container on failure
+          containers:
+            - name: many-charges-fix-job
+              image: ghcr.io/ministryofjustice/hmpps-devops-tools:latest
+              imagePullPolicy: IfNotPresent
+              command: [ "/bin/sh", "-c" ]
+              args:
+                - curl -XPOST --connect-timeout 5 --max-time 60 http://{{ include "generic-service.fullname" . }}/court-case-admin/cleanup-many-charges-to-sentence
+              securityContext:
+                {{- toYaml .Values.manyChargesToSentenceFixCronjob.securityContext | nindent 16 }}
+  {{- end }}

--- a/helm_deploy/hmpps-remand-and-sentencing-api/values.yaml
+++ b/helm_deploy/hmpps-remand-and-sentencing-api/values.yaml
@@ -97,7 +97,7 @@ documentCleanCronjob:
 
 manyChargesToSentenceFixCronjob:
   enabled: false
-  schedule: "30 2 * * *" # 2:30am every day
+  schedule: "30 2 * * *" # 2:30am daily
   timeZone: Etc/UTC
   securityContext:
     capabilities:

--- a/helm_deploy/hmpps-remand-and-sentencing-api/values.yaml
+++ b/helm_deploy/hmpps-remand-and-sentencing-api/values.yaml
@@ -80,7 +80,20 @@ generic-data-analytics-extractor:
 
 documentCleanCronjob:
   enabled: true
-  schedule: "0 2 * * *"
+  schedule: "0 2 * * *" # 2:00am every day
+  timeZone: Etc/UTC
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+
+manyChargesToSentenceFixCronjob:
+  enabled: true
+  schedule: "30 2 * * *" # 2:30am every day
   timeZone: Etc/UTC
   securityContext:
     capabilities:

--- a/helm_deploy/hmpps-remand-and-sentencing-api/values.yaml
+++ b/helm_deploy/hmpps-remand-and-sentencing-api/values.yaml
@@ -84,7 +84,7 @@ generic-data-analytics-extractor:
 
 documentCleanCronjob:
   enabled: true
-  schedule: "0 2 * * *" # 2:00am every day
+  schedule: "0 2 * * *" # 2:00am daily
   timeZone: Etc/UTC
   securityContext:
     capabilities:
@@ -96,7 +96,7 @@ documentCleanCronjob:
       type: RuntimeDefault
 
 manyChargesToSentenceFixCronjob:
-  enabled: true
+  enabled: false
   schedule: "30 2 * * *" # 2:30am every day
   timeZone: Etc/UTC
   securityContext:

--- a/helm_deploy/hmpps-remand-and-sentencing-api/values.yaml
+++ b/helm_deploy/hmpps-remand-and-sentencing-api/values.yaml
@@ -28,6 +28,10 @@ generic-service:
           deny all;
           return 401;
         }
+        location /court-case-admin/cleanup-many-charges-to-sentence {
+          deny all;
+          return 401;
+        }
   # Environment variables to load into the deployment
   env:
     JAVA_OPTS: "-Xmx512m"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -47,3 +47,7 @@ generic-data-analytics-extractor:
 
 documentCleanCronjob:
   schedule: "0 7 * * 1-5"
+
+manyChargesToSentenceFixCronjob:
+  enabled: true
+  schedule: "30 6 * * 1-5"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/ResourceServerConfiguration.kt
@@ -10,7 +10,13 @@ class ResourceServerConfiguration {
   @Bean
   fun resourceServerCustomizer() = ResourceServerConfigurationCustomizer {
     unauthorizedRequestPaths {
-      addPaths = setOf("/document-admin/cleanup", "/legacy/sentence-type/**", "/queue-admin/retry-all-dlqs", "/event-admin/republish")
+      addPaths = setOf(
+        "/document-admin/cleanup",
+        "/legacy/sentence-type/**",
+        "/queue-admin/retry-all-dlqs",
+        "/event-admin/republish",
+        "/court-case-admin/cleanup-many-charges-to-sentence"
+      )
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/config/ResourceServerConfiguration.kt
@@ -15,7 +15,7 @@ class ResourceServerConfiguration {
         "/legacy/sentence-type/**",
         "/queue-admin/retry-all-dlqs",
         "/event-admin/republish",
-        "/court-case-admin/cleanup-many-charges-to-sentence"
+        "/court-case-admin/cleanup-many-charges-to-sentence",
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseAdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseAdminController.kt
@@ -12,19 +12,17 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.BulkFixManyChargesToSentenceService
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.DpsDomainEventService
 
 @RestController
 @RequestMapping("/court-case-admin", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Tag(name = "court-case-admin-controller", description = "Court case")
 class CourtCaseAdminController(
   private val bulkFixManyChargesToSentenceService: BulkFixManyChargesToSentenceService,
-  private val dpsDomainEventService: DpsDomainEventService,
   @Value("\${multiple-charges-single-sentence-fix-queue.limit:500}") private val limit: Int,
 ) {
 
   @PostMapping("/cleanup-many-charges-to-sentence")
-  @ResponseStatus(HttpStatus.OK)
+  @ResponseStatus(HttpStatus.ACCEPTED)
   @Operation(
     summary = "Fixes the single sentence to many charges issue",
     description = """
@@ -35,11 +33,10 @@ class CourtCaseAdminController(
   )
   @ApiResponses(
     value = [
-      ApiResponse(responseCode = "200", description = "Cleanup completed"),
+      ApiResponse(responseCode = "202", description = "Cleanup tiggered"),
     ],
   )
   fun cleanupManyChargesToSentence() {
-    val events = bulkFixManyChargesToSentenceService.fixCourtCaseSentences(limit)
-    dpsDomainEventService.emitEvents(events)
+    bulkFixManyChargesToSentenceService.fixCourtCaseSentences(limit)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseAdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseAdminController.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.BulkFixManyChargesToSentenceService
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.DpsDomainEventService
+
+@RestController
+@RequestMapping("/court-case-admin", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(name = "court-case-admin-controller", description = "Court case")
+class CourtCaseAdminController(
+  private val bulkFixManyChargesToSentenceService: BulkFixManyChargesToSentenceService,
+  private val dpsDomainEventService: DpsDomainEventService,
+  @Value("\${multiple-charges-single-sentence-fix-queue.limit:500}") private val limit: Int,
+) {
+
+  @PostMapping("/cleanup-many-charges-to-sentence")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Fixes the single sentence to many charges issue",
+    description = """
+      NOMIS contains an erroneous relationship between sentences and charges where a single sentence is 
+      linked to multiple charges. This endpoint identifies all court cases with this issue and creates 
+      new sentences for each charge, ensuring that each sentence is correctly linked to its respective charge.
+      """,
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "200", description = "Cleanup completed"),
+    ],
+  )
+  fun cleanupManyChargesToSentence() {
+    val events = bulkFixManyChargesToSentenceService.fixCourtCaseSentences(limit)
+    dpsDomainEventService.emitEvents(events)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/repository/CourtCaseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/repository/CourtCaseRepository.kt
@@ -314,4 +314,21 @@ interface CourtCaseRepository :
       SentenceEntityStatus.MANY_CHARGES_DATA_FIX,
     ),
   ): CourtCaseEntity?
+
+  @Query(
+    value = """SELECT cc.case_unique_identifier      
+               FROM court_case cc      
+               WHERE EXISTS (SELECT 1 
+                             FROM court_appearance cap 
+                             JOIN appearance_charge ac ON ac.appearance_id = cap.id
+                             JOIN charge c ON c.id = ac.charge_id
+                             JOIN sentence s ON s.charge_id = c.id
+                             WHERE cap.court_case_id = cc.id 
+                             AND s.status_id = 'MANY_CHARGES_DATA_FIX')      
+               ORDER BY cc.updated_at DESC      
+               LIMIT :limit    
+           """,
+    nativeQuery = true,
+  )
+  fun findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(@Param("limit") limit: Int): List<String>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/repository/CourtCaseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/jpa/repository/CourtCaseRepository.kt
@@ -316,7 +316,7 @@ interface CourtCaseRepository :
   ): CourtCaseEntity?
 
   @Query(
-    value = """SELECT cc.case_unique_identifier      
+    value = """SELECT cc.id      
                FROM court_case cc      
                WHERE EXISTS (SELECT 1 
                              FROM court_appearance cap 
@@ -330,5 +330,5 @@ interface CourtCaseRepository :
            """,
     nativeQuery = true,
   )
-  fun findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(@Param("limit") limit: Int): List<String>
+  fun findIdWithManyChargesDataFixByUpdatedAtDesc(@Param("limit") limit: Int): Set<Int>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceService.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventMetadata
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.CourtCaseRepository
+
+@Service
+class BulkFixManyChargesToSentenceService(
+  private val fixManyChargesToSentenceService: FixManyChargesToSentenceService,
+  private val courtCaseRepository: CourtCaseRepository,
+) {
+
+  @Transactional
+  fun fixCourtCaseSentences(limit: Int): Set<EventMetadata> {
+    val events = mutableSetOf<EventMetadata>()
+    courtCaseRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(limit).forEach { courtCaseUuid ->
+      courtCaseRepository.findSentencedCourtCase(courtCaseUuid)?.let { courtCaseEntity ->
+        events.addAll(fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity, "BATCH_JOB"))
+      }
+    }
+    return events
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceService.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventMetadata
@@ -9,16 +12,24 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.C
 class BulkFixManyChargesToSentenceService(
   private val fixManyChargesToSentenceService: FixManyChargesToSentenceService,
   private val courtCaseRepository: CourtCaseRepository,
+  private val dpsDomainEventService: DpsDomainEventService,
 ) {
 
+  @Async
   @Transactional
-  fun fixCourtCaseSentences(limit: Int): Set<EventMetadata> {
+  fun fixCourtCaseSentences(limit: Int) {
+    log.info("Starting Bulk Fix Many Charges to Single Sentence async job with limit {}", limit)
     val events = mutableSetOf<EventMetadata>()
     courtCaseRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(limit).forEach { courtCaseUuid ->
       courtCaseRepository.findSentencedCourtCase(courtCaseUuid)?.let { courtCaseEntity ->
         events.addAll(fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity, "BATCH_JOB"))
       }
     }
-    return events
+    log.info("Completed Bulk Fix Many Charges to Single Sentence for {} affected court cases. Emitted a total of {} events", limit, events.size)
+    dpsDomainEventService.emitEvents(events)
+  }
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceService.kt
@@ -20,11 +20,8 @@ class BulkFixManyChargesToSentenceService(
   fun fixCourtCaseSentences(limit: Int) {
     log.info("Starting Bulk Fix Many Charges to Single Sentence async job with limit {}", limit)
     val events = mutableSetOf<EventMetadata>()
-    courtCaseRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(limit).forEach { courtCaseUuid ->
-      courtCaseRepository.findSentencedCourtCase(courtCaseUuid)?.let { courtCaseEntity ->
-        events.addAll(fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity, "BATCH_JOB"))
-      }
-    }
+    val courtCaseUuids = courtCaseRepository.findIdWithManyChargesDataFixByUpdatedAtDesc(limit)
+    events.addAll(fixManyChargesToSentenceService.fixCourtCasesById(courtCaseUuids, "BATCH_JOB"))
     log.info("Completed Bulk Fix Many Charges to Single Sentence for {} affected court cases. Emitted a total of {} events", limit, events.size)
     dpsDomainEventService.emitEvents(events)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/FixManyChargesToSentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/FixManyChargesToSentenceService.kt
@@ -34,7 +34,7 @@ class FixManyChargesToSentenceService(
     fixSentences(courtCaseToSentences(courtCase))
   }.toMutableSet()
 
-  fun fixCourtCaseSentences(courtCase: CourtCaseEntity, username: String? = null): MutableSet<EventMetadata> = fixSentences(courtCaseToSentences(courtCase), username)
+  fun fixCourtCaseSentences(courtCase: CourtCaseEntity): MutableSet<EventMetadata> = fixSentences(courtCaseToSentences(courtCase))
 
   fun fixCourtCaseSentences(courtCases: List<CourtCaseEntity>): MutableSet<EventMetadata> = courtCases.flatMap { courtCase ->
     fixSentences(courtCaseToSentences(courtCase))
@@ -51,8 +51,8 @@ class FixManyChargesToSentenceService(
     }
   }
 
-  fun fixCourtCasesById(courtCaseIds: Set<Int>): MutableSet<EventMetadata> = courtCaseRepository.findAllById(courtCaseIds).flatMap { courtCase ->
-    fixSentences(courtCaseToSentences(courtCase))
+  fun fixCourtCasesById(courtCaseIds: Set<Int>, username: String? = null): MutableSet<EventMetadata> = courtCaseRepository.findAllById(courtCaseIds).flatMap { courtCase ->
+    fixSentences(courtCaseToSentences(courtCase), username)
   }.toMutableSet()
 
   fun fixSentencesBySentenceUuids(sentenceUuids: List<RecordEventMetadata<UUID>>): MutableSet<EventMetadata> = fixSentences(sentenceRepository.findBySentenceUuidIn(sentenceUuids.map { it.record }).map { sentenceEntity -> sentenceUuids.first { it.record == sentenceEntity.sentenceUuid }.toNewRecord(sentenceEntity) })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/FixManyChargesToSentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/FixManyChargesToSentenceService.kt
@@ -81,11 +81,13 @@ class FixManyChargesToSentenceService(
     return eventsToEmit
   }
 
-  private fun fixSentence(sentenceRecordEventMetadata: RecordEventMetadata<SentenceEntity>,
-                          sentenceEventType: EventType,
-                          originalSentenceUuid: UUID,
-                          username: String? = null,
-                          sentenceModifyFunction: (SentenceEntity) -> Unit = {}): EventMetadata {
+  private fun fixSentence(
+    sentenceRecordEventMetadata: RecordEventMetadata<SentenceEntity>,
+    sentenceEventType: EventType,
+    originalSentenceUuid: UUID,
+    username: String? = null,
+    sentenceModifyFunction: (SentenceEntity) -> Unit = {},
+  ): EventMetadata {
     val (sentenceRecord, eventMetadata) = sentenceRecordEventMetadata
     sentenceRecord.statusId = if (sentenceRecord.legacyData?.active == false) SentenceEntityStatus.INACTIVE else SentenceEntityStatus.ACTIVE
     sentenceRecord.updatedAt = ZonedDateTime.now()
@@ -103,9 +105,11 @@ class FixManyChargesToSentenceService(
     )
   }
 
-  private fun fixPeriodLengths(sentenceRecordEventMetadata: RecordEventMetadata<SentenceEntity>,
-                               username: String? = null,
-                               periodLengthModifyFunction: (PeriodLengthEntity) -> Unit = {}): MutableSet<EventMetadata> {
+  private fun fixPeriodLengths(
+    sentenceRecordEventMetadata: RecordEventMetadata<SentenceEntity>,
+    username: String? = null,
+    periodLengthModifyFunction: (PeriodLengthEntity) -> Unit = {},
+  ): MutableSet<EventMetadata> {
     val (sentenceRecord, eventMetadata) = sentenceRecordEventMetadata
     val periodLengthEventsToEmit = mutableSetOf<EventMetadata>()
     val periodLengths = sentenceRecordEventMetadata.record.periodLengths

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/FixManyChargesToSentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/FixManyChargesToSentenceService.kt
@@ -34,7 +34,7 @@ class FixManyChargesToSentenceService(
     fixSentences(courtCaseToSentences(courtCase))
   }.toMutableSet()
 
-  fun fixCourtCaseSentences(courtCase: CourtCaseEntity): MutableSet<EventMetadata> = fixSentences(courtCaseToSentences(courtCase))
+  fun fixCourtCaseSentences(courtCase: CourtCaseEntity, username: String? = null): MutableSet<EventMetadata> = fixSentences(courtCaseToSentences(courtCase), username)
 
   fun fixCourtCaseSentences(courtCases: List<CourtCaseEntity>): MutableSet<EventMetadata> = courtCases.flatMap { courtCase ->
     fixSentences(courtCaseToSentences(courtCase))
@@ -57,35 +57,39 @@ class FixManyChargesToSentenceService(
 
   fun fixSentencesBySentenceUuids(sentenceUuids: List<RecordEventMetadata<UUID>>): MutableSet<EventMetadata> = fixSentences(sentenceRepository.findBySentenceUuidIn(sentenceUuids.map { it.record }).map { sentenceEntity -> sentenceUuids.first { it.record == sentenceEntity.sentenceUuid }.toNewRecord(sentenceEntity) })
 
-  fun fixSentences(sentences: List<RecordEventMetadata<SentenceEntity>>): MutableSet<EventMetadata> {
+  fun fixSentences(sentences: List<RecordEventMetadata<SentenceEntity>>, username: String? = null): MutableSet<EventMetadata> {
     val toFixSentences = sentences
       .filter { it.record.statusId == SentenceEntityStatus.MANY_CHARGES_DATA_FIX }
       .groupByTo(mutableMapOf()) { it.record.sentenceUuid }
     val eventsToEmit = mutableSetOf<EventMetadata>()
     toFixSentences.forEach { (originalSentenceUuid, sentenceRecords) ->
       val firstSentenceRecordEventMetadata = sentenceRecords.removeFirst()
-      val firstSentenceEventToEmit = fixSentence(firstSentenceRecordEventMetadata, EventType.SENTENCE_UPDATED, originalSentenceUuid)
+      val firstSentenceEventToEmit = fixSentence(firstSentenceRecordEventMetadata, EventType.SENTENCE_UPDATED, originalSentenceUuid, username)
       eventsToEmit.add(firstSentenceEventToEmit)
-      fixPeriodLengths(firstSentenceRecordEventMetadata)
+      fixPeriodLengths(firstSentenceRecordEventMetadata, username)
 
       sentenceRecords.forEach { sentenceRecordEventMetadata ->
-        val sentenceEventToEmit = fixSentence(sentenceRecordEventMetadata, EventType.SENTENCE_FIX_SINGLE_CHARGE_INSERTED, originalSentenceUuid) {
+        val sentenceEventToEmit = fixSentence(sentenceRecordEventMetadata, EventType.SENTENCE_FIX_SINGLE_CHARGE_INSERTED, originalSentenceUuid, username) {
           it.sentenceUuid = UUID.randomUUID()
           it.legacyData?.nomisLineReference = null
         }
         eventsToEmit.add(sentenceEventToEmit)
-        val periodLengthEventsToEmit = fixPeriodLengths(sentenceRecordEventMetadata) { it.periodLengthUuid = UUID.randomUUID() }
+        val periodLengthEventsToEmit = fixPeriodLengths(sentenceRecordEventMetadata, username) { it.periodLengthUuid = UUID.randomUUID() }
         eventsToEmit.addAll(periodLengthEventsToEmit)
       }
     }
     return eventsToEmit
   }
 
-  private fun fixSentence(sentenceRecordEventMetadata: RecordEventMetadata<SentenceEntity>, sentenceEventType: EventType, originalSentenceUuid: UUID, sentenceModifyFunction: (SentenceEntity) -> Unit = {}): EventMetadata {
+  private fun fixSentence(sentenceRecordEventMetadata: RecordEventMetadata<SentenceEntity>,
+                          sentenceEventType: EventType,
+                          originalSentenceUuid: UUID,
+                          username: String? = null,
+                          sentenceModifyFunction: (SentenceEntity) -> Unit = {}): EventMetadata {
     val (sentenceRecord, eventMetadata) = sentenceRecordEventMetadata
     sentenceRecord.statusId = if (sentenceRecord.legacyData?.active == false) SentenceEntityStatus.INACTIVE else SentenceEntityStatus.ACTIVE
     sentenceRecord.updatedAt = ZonedDateTime.now()
-    sentenceRecord.updatedBy = serviceUserService.getUsername()
+    sentenceRecord.updatedBy = username ?: serviceUserService.getUsername()
     sentenceModifyFunction(sentenceRecord)
     sentenceHistoryRepository.save(SentenceHistoryEntity.from(sentenceRecord, ChangeSource.DPS))
     return EventMetadataCreator.fixSentenceEventMetadata(
@@ -99,7 +103,9 @@ class FixManyChargesToSentenceService(
     )
   }
 
-  private fun fixPeriodLengths(sentenceRecordEventMetadata: RecordEventMetadata<SentenceEntity>, periodLengthModifyFunction: (PeriodLengthEntity) -> Unit = {}): MutableSet<EventMetadata> {
+  private fun fixPeriodLengths(sentenceRecordEventMetadata: RecordEventMetadata<SentenceEntity>,
+                               username: String? = null,
+                               periodLengthModifyFunction: (PeriodLengthEntity) -> Unit = {}): MutableSet<EventMetadata> {
     val (sentenceRecord, eventMetadata) = sentenceRecordEventMetadata
     val periodLengthEventsToEmit = mutableSetOf<EventMetadata>()
     val periodLengths = sentenceRecordEventMetadata.record.periodLengths
@@ -107,7 +113,7 @@ class FixManyChargesToSentenceService(
       .forEach { periodLength ->
         periodLength.statusId = PeriodLengthEntityStatus.ACTIVE
         periodLength.updatedAt = ZonedDateTime.now()
-        periodLength.updatedBy = serviceUserService.getUsername()
+        periodLength.updatedBy = username ?: serviceUserService.getUsername()
         periodLengthModifyFunction(periodLength)
         periodLengthHistoryRepository.save(PeriodLengthHistoryEntity.from(periodLength, ChangeSource.DPS))
         periodLengthEventsToEmit.add(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/PostCleanupManyChargesToSentenceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/PostCleanupManyChargesToSentenceTests.kt
@@ -115,28 +115,28 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
   )
 
   private fun arrange(totalChargesToSentence: Long = 50, totalCourtCases: Long = 1) {
-    (1L..totalCourtCases).forEach { s ->
-      val sentence = DataCreator.migrationCreateSentence()
+    val courtCasesList = (1L..totalCourtCases).map { id ->
+      val sentence = DataCreator.migrationCreateSentence(sentenceId = DataCreator.migrationSentenceId(offenderBookingId = id))
       val charges = mutableListOf<MigrationCreateCharge>()
-      (1L..totalChargesToSentence).forEach { i ->
-        charges.add(DataCreator.migrationCreateCharge(chargeNOMISId = i, sentence = sentence))
+      (1L..totalChargesToSentence).forEach {
+        charges.add(DataCreator.migrationCreateCharge(chargeNOMISId = it, sentence = sentence))
       }
       val appearance = DataCreator.migrationCreateCourtAppearance(charges = charges)
-      val courtCase = DataCreator.migrationCreateCourtCase(appearances = listOf(appearance))
-      val courtCases = DataCreator.migrationCreateCourtCases(courtCases = listOf(courtCase))
-      webTestClient
-        .post()
-        .uri("/legacy/court-case/migration")
-        .bodyValue(courtCases)
-        .headers {
-          it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_COURT_CASE_RW"))
-          it.contentType = MediaType.APPLICATION_JSON
-        }
-        .exchange()
-        .expectStatus()
-        .isCreated
-        .returnResult<MigrationCreateCourtCasesResponse>()
-        .responseBody.blockFirst()!!
+      DataCreator.migrationCreateCourtCase(appearances = listOf(appearance))
     }
+    val courtCases = DataCreator.migrationCreateCourtCases(courtCases = courtCasesList)
+    webTestClient
+      .post()
+      .uri("/legacy/court-case/migration")
+      .bodyValue(courtCases)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_COURT_CASE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus()
+      .isCreated
+      .returnResult<MigrationCreateCourtCasesResponse>()
+      .responseBody.blockFirst()!!
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/PostCleanupManyChargesToSentenceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/PostCleanupManyChargesToSentenceTests.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.courtcase
 
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
@@ -11,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.Inte
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.DataCreator
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.MigrationCreateCharge
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.MigrationCreateCourtCasesResponse
+import java.time.Duration.ofSeconds
 
 class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
 
@@ -31,7 +33,13 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
       .uri("/court-case-admin/cleanup-many-charges-to-sentence")
       .headers { it.contentType = MediaType.APPLICATION_JSON }
       .exchange()
-      .expectStatus().isOk
+      .expectStatus()
+      .isAccepted
+
+    await().atMost(ofSeconds(10)).until {
+      val count = initialDuplicateSentences?.minus(getDuplicateSentenceCount() ?: 0)
+      count == 30L
+    }
 
     val totalCorrectedSentences = initialDuplicateSentences?.minus(getDuplicateSentenceCount() ?: 0)
     assertThat(totalCorrectedSentences).isEqualTo(30)
@@ -56,7 +64,11 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
       .uri("/court-case-admin/cleanup-many-charges-to-sentence")
       .headers { it.contentType = MediaType.APPLICATION_JSON }
       .exchange()
-      .expectStatus().isOk
+      .expectStatus().isAccepted
+
+    await().atMost(ofSeconds(10)).until {
+      getDuplicateSentenceCount() == 0L
+    }
 
     val totalCorrectedSentences = initialDuplicateSentences?.minus(getDuplicateSentenceCount() ?: 0)
     assertThat(totalCorrectedSentences).isEqualTo(0)
@@ -78,7 +90,7 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
       .uri("/court-case-admin/cleanup-many-charges-to-sentence")
       .headers { it.contentType = MediaType.APPLICATION_JSON }
       .exchange()
-      .expectStatus().isOk
+      .expectStatus().isAccepted
 
     val overallTotalSentenceCount = getSentenceCount()
     assertThat(overallTotalSentenceCount).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/PostCleanupManyChargesToSentenceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/PostCleanupManyChargesToSentenceTests.kt
@@ -20,8 +20,8 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
   @Test
   fun `should cleanup many charges of a single sentence`() {
     arrange(totalChargesToSentence = 4, totalCourtCases = 30)
-    val initialOverallSentenceCount = getSentenceCount();
-    val initialDuplicateSentences = getDuplicateSentenceCount();
+    val initialOverallSentenceCount = getSentenceCount()
+    val initialDuplicateSentences = getDuplicateSentenceCount()
     assertThat(initialDuplicateSentences).isEqualTo(30)
     assertThat(initialOverallSentenceCount).isEqualTo(120) // 30 * 4
 
@@ -35,7 +35,7 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
 
     val totalCorrectedSentences = initialDuplicateSentences?.minus(getDuplicateSentenceCount() ?: 0)
     assertThat(totalCorrectedSentences).isEqualTo(30)
-    val overallTotalSentenceCount = getSentenceCount();
+    val overallTotalSentenceCount = getSentenceCount()
     assertThat(overallTotalSentenceCount).isEqualTo(120)
 
     val totalMessage = getMessages(expectedNumberOfMessages = 210).count { p -> p.eventType == "sentence.fix-single-charge.inserted" }
@@ -45,8 +45,8 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
   @Test
   fun `should not affect single charges to a single sentence`() {
     arrange(totalChargesToSentence = 1, totalCourtCases = 30)
-    val initialOverallSentenceCount = getSentenceCount();
-    val initialDuplicateSentences = getDuplicateSentenceCount();
+    val initialOverallSentenceCount = getSentenceCount()
+    val initialDuplicateSentences = getDuplicateSentenceCount()
     assertThat(initialDuplicateSentences).isEqualTo(0)
     assertThat(initialOverallSentenceCount).isEqualTo(30) // 30 * 1
 
@@ -69,7 +69,7 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
 
   @Test
   fun `should run without any sentences in the db`() {
-    val initialOverallSentenceCount = getSentenceCount();
+    val initialOverallSentenceCount = getSentenceCount()
     assertThat(initialOverallSentenceCount).isEqualTo(0)
 
     // Act
@@ -127,5 +127,4 @@ class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
         .responseBody.blockFirst()!!
     }
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/PostCleanupManyChargesToSentenceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/PostCleanupManyChargesToSentenceTests.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.courtcase
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.queryForObject
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.DataCreator
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.MigrationCreateCharge
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.MigrationCreateCourtCasesResponse
+
+class PostCleanupManyChargesToSentenceTests : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var jdbcTemplate: JdbcTemplate
+
+  @Test
+  fun `should cleanup many charges of a single sentence`() {
+    arrange(totalChargesToSentence = 4, totalCourtCases = 30)
+    val initialOverallSentenceCount = getSentenceCount();
+    val initialDuplicateSentences = getDuplicateSentenceCount();
+    assertThat(initialDuplicateSentences).isEqualTo(30)
+    assertThat(initialOverallSentenceCount).isEqualTo(120) // 30 * 4
+
+    // Act
+    webTestClient
+      .post()
+      .uri("/court-case-admin/cleanup-many-charges-to-sentence")
+      .headers { it.contentType = MediaType.APPLICATION_JSON }
+      .exchange()
+      .expectStatus().isOk
+
+    val totalCorrectedSentences = initialDuplicateSentences?.minus(getDuplicateSentenceCount() ?: 0)
+    assertThat(totalCorrectedSentences).isEqualTo(30)
+    val overallTotalSentenceCount = getSentenceCount();
+    assertThat(overallTotalSentenceCount).isEqualTo(120)
+
+    val totalMessage = getMessages(expectedNumberOfMessages = 210).count { p -> p.eventType == "sentence.fix-single-charge.inserted" }
+    assertThat(totalMessage).isEqualTo(90) // total charges - 1 * court cases fixed
+  }
+
+  @Test
+  fun `should not affect single charges to a single sentence`() {
+    arrange(totalChargesToSentence = 1, totalCourtCases = 30)
+    val initialOverallSentenceCount = getSentenceCount();
+    val initialDuplicateSentences = getDuplicateSentenceCount();
+    assertThat(initialDuplicateSentences).isEqualTo(0)
+    assertThat(initialOverallSentenceCount).isEqualTo(30) // 30 * 1
+
+    // Act
+    webTestClient
+      .post()
+      .uri("/court-case-admin/cleanup-many-charges-to-sentence")
+      .headers { it.contentType = MediaType.APPLICATION_JSON }
+      .exchange()
+      .expectStatus().isOk
+
+    val totalCorrectedSentences = initialDuplicateSentences?.minus(getDuplicateSentenceCount() ?: 0)
+    assertThat(totalCorrectedSentences).isEqualTo(0)
+    val overallTotalSentenceCount = getSentenceCount()
+    assertThat(overallTotalSentenceCount).isEqualTo(30)
+
+    val totalMessage = getMessages(expectedNumberOfMessages = 0).count()
+    assertThat(totalMessage).isEqualTo(0)
+  }
+
+  @Test
+  fun `should run without any sentences in the db`() {
+    val initialOverallSentenceCount = getSentenceCount();
+    assertThat(initialOverallSentenceCount).isEqualTo(0)
+
+    // Act
+    webTestClient
+      .post()
+      .uri("/court-case-admin/cleanup-many-charges-to-sentence")
+      .headers { it.contentType = MediaType.APPLICATION_JSON }
+      .exchange()
+      .expectStatus().isOk
+
+    val overallTotalSentenceCount = getSentenceCount()
+    assertThat(overallTotalSentenceCount).isEqualTo(0)
+
+    val totalMessage = getMessages(expectedNumberOfMessages = 0).count()
+    assertThat(totalMessage).isEqualTo(0)
+  }
+
+  private fun getSentenceCount(): Long? = jdbcTemplate.queryForObject<Long>(
+    """SELECT count(*)
+             FROM sentence             
+    """.trimIndent(),
+  )
+
+  private fun getDuplicateSentenceCount(): Long? = jdbcTemplate.queryForObject<Long>(
+    """SELECT COUNT(*)
+             FROM (SELECT sentence_uuid
+                  FROM sentence
+                  GROUP BY sentence_uuid
+                  HAVING COUNT(*) > 1) duplicates
+    """.trimIndent(),
+  )
+
+  private fun arrange(totalChargesToSentence: Long = 50, totalCourtCases: Long = 1) {
+    (1L..totalCourtCases).forEach { s ->
+      val sentence = DataCreator.migrationCreateSentence()
+      val charges = mutableListOf<MigrationCreateCharge>()
+      (1L..totalChargesToSentence).forEach { i ->
+        charges.add(DataCreator.migrationCreateCharge(chargeNOMISId = i, sentence = sentence))
+      }
+      val appearance = DataCreator.migrationCreateCourtAppearance(charges = charges)
+      val courtCase = DataCreator.migrationCreateCourtCase(appearances = listOf(appearance))
+      val courtCases = DataCreator.migrationCreateCourtCases(courtCases = listOf(courtCase))
+      webTestClient
+        .post()
+        .uri("/legacy/court-case/migration")
+        .bodyValue(courtCases)
+        .headers {
+          it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_COURT_CASE_RW"))
+          it.contentType = MediaType.APPLICATION_JSON
+        }
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .returnResult<MigrationCreateCourtCasesResponse>()
+        .responseBody.blockFirst()!!
+    }
+  }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
@@ -4,18 +4,14 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventMetadata
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventType
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.ChargeEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.CourtCaseEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.CourtCaseRepository
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.subjectaccessrequest.RecallSarRepository
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.subjectaccessrequest.MockedResponseData
 
 @ExtendWith(MockKExtension::class)
 class BulkFixManyChargesToSentenceServiceTests {
@@ -25,7 +21,7 @@ class BulkFixManyChargesToSentenceServiceTests {
 
   @MockK
   private lateinit var fixManyChargesToSentenceService: FixManyChargesToSentenceService
-  
+
   @MockK
   private lateinit var courtCaseEntity1: CourtCaseEntity
 
@@ -43,12 +39,11 @@ class BulkFixManyChargesToSentenceServiceTests {
 
   @Test
   fun `should call fixCourtCaseSentences multiple times returning the sum of all generated events`() {
-
     every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(4) } returns listOf(
       "70D8677F-3E37-487D-ADA7-EEFE3182438B",
       "B9C71F09-A5C0-4355-B961-BFC229EE7104",
       "28DA01FA-EEC5-4541-890C-F0A0FDD11772",
-      "001AE716-4F8E-4C04-B855-2DCCCF5EFA24"
+      "001AE716-4F8E-4C04-B855-2DCCCF5EFA24",
     )
 
     every { courtCaseSarRepository.findSentencedCourtCase("70D8677F-3E37-487D-ADA7-EEFE3182438B") } returns courtCaseEntity1
@@ -68,7 +63,6 @@ class BulkFixManyChargesToSentenceServiceTests {
 
   @Test
   fun `should call fixCourtCaseSentences once returning the generated events for that fix`() {
-
     every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(1) } returns listOf(
       "70D8677F-3E37-487D-ADA7-EEFE3182438B",
     )
@@ -84,7 +78,6 @@ class BulkFixManyChargesToSentenceServiceTests {
 
   @Test
   fun `should do nothing when query returns and empty list`() {
-
     every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(1) } returns listOf()
 
     val events = sut.fixCourtCaseSentences(1)
@@ -93,20 +86,16 @@ class BulkFixManyChargesToSentenceServiceTests {
     verify(exactly = 0) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
   }
 
-
-  fun events(prisonerId: Int): MutableSet<EventMetadata> {
-    return mutableSetOf(
-      EventMetadata(prisonerId = "A1234AA$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "B2345BB$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "C3456CC$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "D4567DD$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "E5678EE$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "F6789FF$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "G7890GG$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "H8901HH$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "I9012II$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
-      EventMetadata(prisonerId = "J0123JJ$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED)
-    )
-  }
-
+  fun events(prisonerId: Int): MutableSet<EventMetadata> = mutableSetOf(
+    EventMetadata(prisonerId = "A1234AA$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "B2345BB$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "C3456CC$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "D4567DD$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "E5678EE$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "F6789FF$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "G7890GG$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "H8901HH$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "I9012II$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+    EventMetadata(prisonerId = "J0123JJ$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventMetadata
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.ChargeEntity
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.CourtCaseEntity
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.CourtCaseRepository
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.subjectaccessrequest.RecallSarRepository
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.subjectaccessrequest.MockedResponseData
+
+@ExtendWith(MockKExtension::class)
+class BulkFixManyChargesToSentenceServiceTests {
+
+  @MockK
+  private lateinit var courtCaseSarRepository: CourtCaseRepository
+
+  @MockK
+  private lateinit var fixManyChargesToSentenceService: FixManyChargesToSentenceService
+  
+  @MockK
+  private lateinit var courtCaseEntity: CourtCaseEntity
+
+  @InjectMockKs(overrideValues = true)
+  private lateinit var sut: BulkFixManyChargesToSentenceService
+
+  @Test
+  fun `should foo bar`() {
+
+    every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(10) } returns listOf(
+      "70D8677F-3E37-487D-ADA7-EEFE3182438B",
+      "B9C71F09-A5C0-4355-B961-BFC229EE7104",
+      "28DA01FA-EEC5-4541-890C-F0A0FDD11772",
+      "001AE716-4F8E-4C04-B855-2DCCCF5EFA24"
+    )
+
+    every { courtCaseSarRepository.findSentencedCourtCase("70D8677F-3E37-487D-ADA7-EEFE3182438B") } returns courtCaseEntity
+    every { courtCaseSarRepository.findSentencedCourtCase("B9C71F09-A5C0-4355-B961-BFC229EE7104") } returns courtCaseEntity
+    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity, "BATCH_JOB") } returns 
+    
+    
+    val events = sut.fixCourtCaseSentences(20)
+
+    verify { chargeRepository.save(any()) }
+  }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
@@ -6,9 +6,11 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventMetadata
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventType
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.ChargeEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.CourtCaseEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.CourtCaseRepository
@@ -25,29 +27,86 @@ class BulkFixManyChargesToSentenceServiceTests {
   private lateinit var fixManyChargesToSentenceService: FixManyChargesToSentenceService
   
   @MockK
-  private lateinit var courtCaseEntity: CourtCaseEntity
+  private lateinit var courtCaseEntity1: CourtCaseEntity
+
+  @MockK
+  private lateinit var courtCaseEntity2: CourtCaseEntity
+
+  @MockK
+  private lateinit var courtCaseEntity3: CourtCaseEntity
+
+  @MockK
+  private lateinit var courtCaseEntity4: CourtCaseEntity
 
   @InjectMockKs(overrideValues = true)
   private lateinit var sut: BulkFixManyChargesToSentenceService
 
   @Test
-  fun `should foo bar`() {
+  fun `should call fixCourtCaseSentences multiple times returning the sum of all generated events`() {
 
-    every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(10) } returns listOf(
+    every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(4) } returns listOf(
       "70D8677F-3E37-487D-ADA7-EEFE3182438B",
       "B9C71F09-A5C0-4355-B961-BFC229EE7104",
       "28DA01FA-EEC5-4541-890C-F0A0FDD11772",
       "001AE716-4F8E-4C04-B855-2DCCCF5EFA24"
     )
 
-    every { courtCaseSarRepository.findSentencedCourtCase("70D8677F-3E37-487D-ADA7-EEFE3182438B") } returns courtCaseEntity
-    every { courtCaseSarRepository.findSentencedCourtCase("B9C71F09-A5C0-4355-B961-BFC229EE7104") } returns courtCaseEntity
-    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity, "BATCH_JOB") } returns 
-    
-    
-    val events = sut.fixCourtCaseSentences(20)
+    every { courtCaseSarRepository.findSentencedCourtCase("70D8677F-3E37-487D-ADA7-EEFE3182438B") } returns courtCaseEntity1
+    every { courtCaseSarRepository.findSentencedCourtCase("B9C71F09-A5C0-4355-B961-BFC229EE7104") } returns courtCaseEntity2
+    every { courtCaseSarRepository.findSentencedCourtCase("28DA01FA-EEC5-4541-890C-F0A0FDD11772") } returns courtCaseEntity3
+    every { courtCaseSarRepository.findSentencedCourtCase("001AE716-4F8E-4C04-B855-2DCCCF5EFA24") } returns courtCaseEntity4
+    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity1, "BATCH_JOB") } returns events(5)
+    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity2, "BATCH_JOB") } returns events(3)
+    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity3, "BATCH_JOB") } returns events(66)
+    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity4, "BATCH_JOB") } returns events(1)
 
-    verify { chargeRepository.save(any()) }
+    val events = sut.fixCourtCaseSentences(4)
+
+    assertThat(events).size().isEqualTo(40)
+    verify(exactly = 4) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
+  }
+
+  @Test
+  fun `should call fixCourtCaseSentences once returning the generated events for that fix`() {
+
+    every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(1) } returns listOf(
+      "70D8677F-3E37-487D-ADA7-EEFE3182438B",
+    )
+
+    every { courtCaseSarRepository.findSentencedCourtCase("70D8677F-3E37-487D-ADA7-EEFE3182438B") } returns courtCaseEntity1
+    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity1, "BATCH_JOB") } returns events(5)
+
+    val events = sut.fixCourtCaseSentences(1)
+
+    assertThat(events).size().isEqualTo(10)
+    verify(exactly = 1) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
+  }
+
+  @Test
+  fun `should do nothing when query returns and empty list`() {
+
+    every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(1) } returns listOf()
+
+    val events = sut.fixCourtCaseSentences(1)
+
+    assertThat(events).size().isEqualTo(0)
+    verify(exactly = 0) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
+  }
+
+
+  fun events(prisonerId: Int): MutableSet<EventMetadata> {
+    return mutableSetOf(
+      EventMetadata(prisonerId = "A1234AA$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "B2345BB$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "C3456CC$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "D4567DD$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "E5678EE$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "F6789FF$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "G7890GG$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "H8901HH$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "I9012II$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED),
+      EventMetadata(prisonerId = "J0123JJ$prisonerId", null, null, null, null, null, eventType = EventType.SENTENCE_UPDATED)
+    )
   }
 
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
@@ -40,58 +40,48 @@ class BulkFixManyChargesToSentenceServiceTests {
   private lateinit var courtCaseEntity4: CourtCaseEntity
 
   @InjectMockKs(overrideValues = true)
-  private lateinit var sut: BulkFixManyChargesToSentenceService
+  private lateinit var bulkFixManyChargesToSentenceService: BulkFixManyChargesToSentenceService
 
   @Test
   fun `should call fixCourtCaseSentences multiple times returning the sum of all generated events`() {
-    every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(4) } returns listOf(
-      "70D8677F-3E37-487D-ADA7-EEFE3182438B",
-      "B9C71F09-A5C0-4355-B961-BFC229EE7104",
-      "28DA01FA-EEC5-4541-890C-F0A0FDD11772",
-      "001AE716-4F8E-4C04-B855-2DCCCF5EFA24",
-    )
-
-    every { courtCaseSarRepository.findSentencedCourtCase("70D8677F-3E37-487D-ADA7-EEFE3182438B") } returns courtCaseEntity1
-    every { courtCaseSarRepository.findSentencedCourtCase("B9C71F09-A5C0-4355-B961-BFC229EE7104") } returns courtCaseEntity2
-    every { courtCaseSarRepository.findSentencedCourtCase("28DA01FA-EEC5-4541-890C-F0A0FDD11772") } returns courtCaseEntity3
-    every { courtCaseSarRepository.findSentencedCourtCase("001AE716-4F8E-4C04-B855-2DCCCF5EFA24") } returns courtCaseEntity4
-    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity1, "BATCH_JOB") } returns events(5)
-    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity2, "BATCH_JOB") } returns events(3)
-    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity3, "BATCH_JOB") } returns events(66)
-    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity4, "BATCH_JOB") } returns events(1)
+    every { courtCaseSarRepository.findIdWithManyChargesDataFixByUpdatedAtDesc(4) } returns setOf(1, 2, 3, 4)
+    every { fixManyChargesToSentenceService.fixCourtCasesById(setOf(1, 2, 3, 4), "BATCH_JOB") } returns events(40)
     every { dpsDomainEventService.emitEvents(any()) } just Runs
 
-    sut.fixCourtCaseSentences(4)
+    // Act
+    bulkFixManyChargesToSentenceService.fixCourtCaseSentences(4)
 
-    verify(exactly = 1) { dpsDomainEventService.emitEvents(withArg { assertThat(it).size().isEqualTo(40) }) }
-    verify(exactly = 4) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
+    verify(exactly = 1) { dpsDomainEventService.emitEvents(withArg { assertThat(it).size().isEqualTo(10) }) }
+    verify(exactly = 1) { fixManyChargesToSentenceService.fixCourtCasesById(any(), "BATCH_JOB") }
   }
 
   @Test
   fun `should call fixCourtCaseSentences once returning the generated events for that fix`() {
-    every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(1) } returns listOf(
-      "70D8677F-3E37-487D-ADA7-EEFE3182438B",
+    every { courtCaseSarRepository.findIdWithManyChargesDataFixByUpdatedAtDesc(1) } returns setOf(
+      1,
     )
 
-    every { courtCaseSarRepository.findSentencedCourtCase("70D8677F-3E37-487D-ADA7-EEFE3182438B") } returns courtCaseEntity1
-    every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity1, "BATCH_JOB") } returns events(5)
+    every { fixManyChargesToSentenceService.fixCourtCasesById(setOf(1), "BATCH_JOB") } returns events(5)
     every { dpsDomainEventService.emitEvents(any()) } just Runs
 
-    sut.fixCourtCaseSentences(1)
+    // Act
+    bulkFixManyChargesToSentenceService.fixCourtCaseSentences(1)
 
     verify(exactly = 1) { dpsDomainEventService.emitEvents(withArg { assertThat(it).size().isEqualTo(10) }) }
-    verify(exactly = 1) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
+    verify(exactly = 1) { fixManyChargesToSentenceService.fixCourtCasesById(any(), "BATCH_JOB") }
   }
 
   @Test
   fun `should do nothing when query returns and empty list`() {
-    every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(1) } returns listOf()
+    every { courtCaseSarRepository.findIdWithManyChargesDataFixByUpdatedAtDesc(1) } returns setOf()
+    every { fixManyChargesToSentenceService.fixCourtCasesById(setOf(), "BATCH_JOB") } returns mutableSetOf()
     every { dpsDomainEventService.emitEvents(any()) } just Runs
 
-    sut.fixCourtCaseSentences(1)
+    // Act
+    bulkFixManyChargesToSentenceService.fixCourtCaseSentences(1)
 
     verify(exactly = 1) { dpsDomainEventService.emitEvents(withArg { assertThat(it).size().isEqualTo(0) }) }
-    verify(exactly = 0) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
+    verify(exactly = 1) { fixManyChargesToSentenceService.fixCourtCasesById(any(), "BATCH_JOB") }
   }
 
   fun events(prisonerId: Int): MutableSet<EventMetadata> = mutableSetOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/BulkFixManyChargesToSentenceServiceTests.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service
 
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.just
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -21,6 +23,9 @@ class BulkFixManyChargesToSentenceServiceTests {
 
   @MockK
   private lateinit var fixManyChargesToSentenceService: FixManyChargesToSentenceService
+
+  @MockK
+  private lateinit var dpsDomainEventService: DpsDomainEventService
 
   @MockK
   private lateinit var courtCaseEntity1: CourtCaseEntity
@@ -54,10 +59,11 @@ class BulkFixManyChargesToSentenceServiceTests {
     every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity2, "BATCH_JOB") } returns events(3)
     every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity3, "BATCH_JOB") } returns events(66)
     every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity4, "BATCH_JOB") } returns events(1)
+    every { dpsDomainEventService.emitEvents(any()) } just Runs
 
-    val events = sut.fixCourtCaseSentences(4)
+    sut.fixCourtCaseSentences(4)
 
-    assertThat(events).size().isEqualTo(40)
+    verify(exactly = 1) { dpsDomainEventService.emitEvents(withArg { assertThat(it).size().isEqualTo(40) }) }
     verify(exactly = 4) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
   }
 
@@ -69,20 +75,22 @@ class BulkFixManyChargesToSentenceServiceTests {
 
     every { courtCaseSarRepository.findSentencedCourtCase("70D8677F-3E37-487D-ADA7-EEFE3182438B") } returns courtCaseEntity1
     every { fixManyChargesToSentenceService.fixCourtCaseSentences(courtCaseEntity1, "BATCH_JOB") } returns events(5)
+    every { dpsDomainEventService.emitEvents(any()) } just Runs
 
-    val events = sut.fixCourtCaseSentences(1)
+    sut.fixCourtCaseSentences(1)
 
-    assertThat(events).size().isEqualTo(10)
+    verify(exactly = 1) { dpsDomainEventService.emitEvents(withArg { assertThat(it).size().isEqualTo(10) }) }
     verify(exactly = 1) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
   }
 
   @Test
   fun `should do nothing when query returns and empty list`() {
     every { courtCaseSarRepository.findCaseUniqueIdentifierWithManyChargesDataFixByUpdatedAtDesc(1) } returns listOf()
+    every { dpsDomainEventService.emitEvents(any()) } just Runs
 
-    val events = sut.fixCourtCaseSentences(1)
+    sut.fixCourtCaseSentences(1)
 
-    assertThat(events).size().isEqualTo(0)
+    verify(exactly = 1) { dpsDomainEventService.emitEvents(withArg { assertThat(it).size().isEqualTo(0) }) }
     verify(exactly = 0) { fixManyChargesToSentenceService.fixCourtCaseSentences(any(), "BATCH_JOB") }
   }
 


### PR DESCRIPTION
## Solution: Rest for bulk many-charges-to-single-sentence data fix

This commit includes a new CourtCaseAdminController as an entry point to fix court cases containing
single sentences mapped to multiple charges. 

Due to the potential run time of the function, the cron job invoking this endpoint will return immediately a 202
with outcomes written to the logs