### PR TITLE
RASS-2334 add is on future appearance to charge events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/EventMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/EventMetadata.kt
@@ -13,4 +13,5 @@ data class EventMetadata(
   val previousRecallId: String? = null,
   val previousSentenceIds: List<String>? = null,
   val originalSentenceId: String? = null,
+  val isOnFutureAppearance: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/event/HmppsCourtChargeMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/event/HmppsCourtChargeMessage.kt
@@ -5,4 +5,5 @@ data class HmppsCourtChargeMessage(
   val courtCaseId: String,
   val source: EventSource = EventSource.DPS,
   val courtAppearanceId: String? = null,
+  val isOnFutureAppearance: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/util/EventMetadataCreator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/util/EventMetadataCreator.kt
@@ -24,7 +24,8 @@ class EventMetadataCreator {
       courtAppearanceId: String?,
       chargeId: String,
       eventType: EventType,
-    ): EventMetadata = EventMetadata(prisonerId, courtCaseId, courtAppearanceId, chargeId, null, null, eventType)
+      isOnFutureAppearance: Boolean,
+    ): EventMetadata = EventMetadata(prisonerId, courtCaseId, courtAppearanceId, chargeId, null, null, eventType, isOnFutureAppearance = isOnFutureAppearance)
 
     fun sentenceEventMetadata(
       prisonerId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/LegacyChargeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/LegacyChargeController.kt
@@ -18,21 +18,19 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.event.EventSource
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.EntityChangeStatus
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyCharge
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyChargeCreatedResponse
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyCreateCharge
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyUpdateCharge
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyUpdateWholeCharge
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.service.LegacyChargeService
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ChargeDomainEventService
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.service.LegacyDomainEventService
 import java.util.UUID
 
 @RestController
 @RequestMapping("/legacy/charge", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Tag(name = "legacy-charge-controller", description = "CRUD operations for syncing charge data from NOMIS Offender charges into remand and sentencing api database.")
-class LegacyChargeController(private val legacyChargeService: LegacyChargeService, private val eventService: ChargeDomainEventService) {
+class LegacyChargeController(private val legacyChargeService: LegacyChargeService, private val legacyDomainEventService: LegacyDomainEventService) {
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
@@ -48,8 +46,9 @@ class LegacyChargeController(private val legacyChargeService: LegacyChargeServic
     ],
   )
   @PreAuthorize("hasRole('ROLE_REMAND_AND_SENTENCING_CHARGE_RW')")
-  fun create(@RequestBody charge: LegacyCreateCharge): LegacyChargeCreatedResponse = legacyChargeService.create(charge).also {
-    eventService.create(it.prisonerId, it.lifetimeUuid.toString(), it.courtCaseUuid, charge.appearanceLifetimeUuid.toString(), EventSource.NOMIS)
+  fun create(@RequestBody charge: LegacyCreateCharge): LegacyChargeCreatedResponse = legacyChargeService.create(charge).let {
+    legacyDomainEventService.emitEvents(it.eventsToEmit)
+    it.record
   }
 
   @PutMapping("/{lifetimeUuid}")
@@ -84,10 +83,8 @@ class LegacyChargeController(private val legacyChargeService: LegacyChargeServic
   )
   @PreAuthorize("hasRole('ROLE_REMAND_AND_SENTENCING_CHARGE_RW')")
   fun updateInAppearance(@PathVariable lifetimeUuid: UUID, @PathVariable appearanceLifetimeUuid: UUID, @RequestBody charge: LegacyUpdateCharge): ResponseEntity<Void> {
-    legacyChargeService.updateInAppearance(lifetimeUuid, appearanceLifetimeUuid, charge).also { (entityChangeStatus, legacyChargeCreatedResponse) ->
-      if (entityChangeStatus == EntityChangeStatus.EDITED) {
-        eventService.update(legacyChargeCreatedResponse.prisonerId, legacyChargeCreatedResponse.lifetimeUuid.toString(), appearanceLifetimeUuid.toString(), legacyChargeCreatedResponse.courtCaseUuid, EventSource.NOMIS)
-      }
+    legacyChargeService.updateInAppearance(lifetimeUuid, appearanceLifetimeUuid, charge).also { (_, eventsToEmit) ->
+      legacyDomainEventService.emitEvents(eventsToEmit)
     }
     return ResponseEntity.noContent().build()
   }
@@ -126,8 +123,8 @@ class LegacyChargeController(private val legacyChargeService: LegacyChargeServic
     @RequestHeader("performedByUser", required = false)
     performedByUser: String?,
   ) {
-    legacyChargeService.delete(chargeUuid, performedByUser)?.also { legacyCharge ->
-      eventService.delete(legacyCharge.prisonerId, legacyCharge.lifetimeUuid.toString(), legacyCharge.courtCaseUuid, EventSource.NOMIS)
+    legacyChargeService.delete(chargeUuid, performedByUser)?.also { eventsToEmit ->
+      legacyDomainEventService.emitEvents(eventsToEmit)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/LegacyCourtAppearanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/LegacyCourtAppearanceController.kt
@@ -29,14 +29,13 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controlle
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.service.LegacyChargeService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.service.LegacyCourtAppearanceService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.service.LegacyDomainEventService
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ChargeDomainEventService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.CourtAppearanceDomainEventService
 import java.util.UUID
 
 @RestController
 @RequestMapping("/legacy/court-appearance", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Tag(name = "legacy-court-appearance-controller", description = "CRUD operations for syncing court appearance data from NOMIS Court Events into remand and sentencing api database.")
-class LegacyCourtAppearanceController(private val legacyCourtAppearanceService: LegacyCourtAppearanceService, private val eventService: CourtAppearanceDomainEventService, private val chargeEventService: ChargeDomainEventService, private val legacyChargeService: LegacyChargeService, private val legacyDomainEventService: LegacyDomainEventService) {
+class LegacyCourtAppearanceController(private val legacyCourtAppearanceService: LegacyCourtAppearanceService, private val eventService: CourtAppearanceDomainEventService, private val legacyChargeService: LegacyChargeService, private val legacyDomainEventService: LegacyDomainEventService) {
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
@@ -190,9 +189,7 @@ class LegacyCourtAppearanceController(private val legacyCourtAppearanceService: 
     ],
   )
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  fun linkChargeToCaseInAppearance(@PathVariable courtAppearanceUuid: UUID, @PathVariable chargeUuid: UUID, @RequestBody linkChargeToCase: LegacyLinkChargeToCase) = legacyChargeService.linkChargeToCase(courtAppearanceUuid, chargeUuid, linkChargeToCase).also { (entityChangeStatus, legacyChargeCreatedResponse) ->
-    if (entityChangeStatus == EntityChangeStatus.EDITED) {
-      chargeEventService.update(legacyChargeCreatedResponse.prisonerId, legacyChargeCreatedResponse.lifetimeUuid.toString(), courtAppearanceUuid.toString(), legacyChargeCreatedResponse.courtCaseUuid, EventSource.NOMIS)
-    }
+  fun linkChargeToCaseInAppearance(@PathVariable courtAppearanceUuid: UUID, @PathVariable chargeUuid: UUID, @RequestBody linkChargeToCase: LegacyLinkChargeToCase) = legacyChargeService.linkChargeToCase(courtAppearanceUuid, chargeUuid, linkChargeToCase).also {
+    legacyDomainEventService.emitEvents(it)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/LegacyCourtCaseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/controller/LegacyCourtCaseController.kt
@@ -27,14 +27,14 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controlle
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.RefreshCaseReferences
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.reconciliation.ReconciliationCourtCase
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.service.LegacyCourtCaseService
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ChargeDomainEventService
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.service.LegacyDomainEventService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.CourtCaseDomainEventService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.legacy.CourtCaseReferenceService
 
 @RestController
 @RequestMapping("/legacy/court-case", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Tag(name = "legacy-court-case-controller", description = "CRUD operations for syncing court case data from NOMIS into remand and sentencing api database.")
-class LegacyCourtCaseController(private val legacyCourtCaseService: LegacyCourtCaseService, private val eventService: CourtCaseDomainEventService, private val chargeEventService: ChargeDomainEventService, private val courtCaseReferenceService: CourtCaseReferenceService) {
+class LegacyCourtCaseController(private val legacyCourtCaseService: LegacyCourtCaseService, private val eventService: CourtCaseDomainEventService, private val courtCaseReferenceService: CourtCaseReferenceService, private val legacyDomainEventService: LegacyDomainEventService) {
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
@@ -149,22 +149,7 @@ class LegacyCourtCaseController(private val legacyCourtCaseService: LegacyCourtC
   @ResponseStatus(HttpStatus.NO_CONTENT)
   fun unlinkCourtCase(@PathVariable sourceCourtCaseUuid: String, @PathVariable targetCourtCaseUuid: String, @RequestBody(required = false) unlinkCase: LegacyUnlinkCase?) = legacyCourtCaseService.unlinkCourtCases(sourceCourtCaseUuid, targetCourtCaseUuid, unlinkCase)
     .also { unlinkEventsToEmit ->
-      unlinkEventsToEmit.courtCaseEventMetadata?.let { courtCaseEventMetaData ->
-        eventService.update(
-          courtCaseEventMetaData.courtCaseId!!,
-          courtCaseEventMetaData.prisonerId,
-          EventSource.NOMIS,
-        )
-      }
-      unlinkEventsToEmit.chargesEventMetadata.forEach { chargeEventMetaData ->
-        chargeEventService.update(
-          chargeEventMetaData.prisonerId,
-          chargeEventMetaData.chargeId!!,
-          chargeEventMetaData.courtAppearanceId!!,
-          chargeEventMetaData.courtCaseId!!,
-          EventSource.NOMIS,
-        )
-      }
+      legacyDomainEventService.emitEvents(unlinkEventsToEmit)
     }
 
   @GetMapping("/{courtCaseUuid}/reconciliation")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/domain/UnlinkEventsToEmit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/domain/UnlinkEventsToEmit.kt
@@ -1,8 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.domain
-
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventMetadata
-
-data class UnlinkEventsToEmit(
-  val courtCaseEventMetadata: EventMetadata?,
-  val chargesEventMetadata: List<EventMetadata>,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/BookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/BookingService.kt
@@ -342,6 +342,7 @@ class BookingService(
         bookingHierarchyData.courtAppearanceId,
         createdCharge.chargeUuid.toString(),
         EventType.CHARGE_INSERTED,
+        false,
       ),
     )
     return createdCharge

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyChargeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyChargeService.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventMetadata
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.EventType
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.RecordResponse
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.util.EventMetadataCreator
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.AppearanceChargeEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.ChargeEntity
@@ -17,7 +18,6 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ChangeS
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ChargeEntityStatus
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtAppearanceEntityStatus
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtCaseEntityStatus
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.EntityChangeStatus
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.SentenceEntityStatus
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.ChargeOutcomeRepository
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.ChargeRepository
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controlle
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ServiceUserService
 import java.time.ZonedDateTime
 import java.util.UUID
+import kotlin.toString
 
 @Service
 class LegacyChargeService(
@@ -48,7 +49,7 @@ class LegacyChargeService(
 ) : LegacyBaseService(chargeRepository, appearanceChargeHistoryRepository, chargeHistoryRepository, serviceUserService) {
 
   @Transactional
-  fun create(charge: LegacyCreateCharge): LegacyChargeCreatedResponse {
+  fun create(charge: LegacyCreateCharge): RecordResponse<LegacyChargeCreatedResponse> {
     val courtAppearance = courtAppearanceRepository.findByAppearanceUuid(charge.appearanceLifetimeUuid)?.takeUnless { entity -> entity.statusId == CourtAppearanceEntityStatus.DELETED } ?: throw EntityNotFoundException("No court appearance found at ${charge.appearanceLifetimeUuid}")
     val dpsOutcome = charge.legacyData.nomisOutcomeCode?.let { nomisCode -> chargeOutcomeRepository.findByNomisCode(nomisCode) }
     charge.legacyData = dpsOutcome?.let { charge.legacyData.copy(nomisOutcomeCode = null, outcomeDescription = null, outcomeDispositionCode = null) } ?: charge.legacyData
@@ -78,7 +79,19 @@ class LegacyChargeService(
         ChangeSource.NOMIS,
       ),
     )
-    return LegacyChargeCreatedResponse(createdCharge.chargeUuid, courtAppearance.courtCase.caseUniqueIdentifier, courtAppearance.courtCase.prisonerId)
+    return RecordResponse(
+      LegacyChargeCreatedResponse(createdCharge.chargeUuid, courtAppearance.courtCase.caseUniqueIdentifier, courtAppearance.courtCase.prisonerId),
+      mutableSetOf(
+        EventMetadataCreator.chargeEventMetadata(
+          courtAppearance.courtCase.prisonerId,
+          courtAppearance.courtCase.caseUniqueIdentifier,
+          courtAppearance.appearanceUuid.toString(),
+          createdCharge.chargeUuid.toString(),
+          EventType.CHARGE_INSERTED,
+          courtAppearance.statusId == CourtAppearanceEntityStatus.FUTURE,
+        ),
+      ),
+    )
   }
 
   @Transactional
@@ -139,6 +152,7 @@ class LegacyChargeService(
           appearanceUuid.toString(),
           chargeUuid.toString(),
           EventType.CHARGE_UPDATED,
+          existingCourtAppearance.statusId == CourtAppearanceEntityStatus.FUTURE,
         ),
       )
       eventsToEmit.add(
@@ -154,26 +168,33 @@ class LegacyChargeService(
   }
 
   @Transactional
-  fun updateInAppearance(lifetimeUuid: UUID, appearanceUuid: UUID, charge: LegacyUpdateCharge): Pair<EntityChangeStatus, LegacyChargeCreatedResponse> {
+  fun updateInAppearance(lifetimeUuid: UUID, appearanceUuid: UUID, charge: LegacyUpdateCharge): RecordResponse<LegacyChargeCreatedResponse> {
     val existingCharge = getAtAppearanceUnlessDeleted(appearanceUuid, lifetimeUuid)
     val existingAppearance = existingCharge.appearanceCharges.first { it.appearance!!.appearanceUuid == appearanceUuid }.appearance!!
-    val (entityChangeStatus, legacyChargeCreatedResponse) = updateChargeInAppearance(existingCharge, lifetimeUuid, existingAppearance, charge)
-    return entityChangeStatus to legacyChargeCreatedResponse
+    return updateChargeInAppearance(existingCharge, lifetimeUuid, existingAppearance, charge)
   }
 
-  private fun updateChargeInAppearance(existingCharge: ChargeEntity, lifetimeUuid: UUID, appearance: CourtAppearanceEntity, charge: LegacyUpdateCharge): UpdateChargeInAppearanceTracking {
-    var entityChangeStatus = EntityChangeStatus.NO_CHANGE
+  private fun updateChargeInAppearance(existingCharge: ChargeEntity, lifetimeUuid: UUID, appearance: CourtAppearanceEntity, charge: LegacyUpdateCharge): RecordResponse<LegacyChargeCreatedResponse> {
+    val eventsToEmit = mutableSetOf<EventMetadata>()
     val updatedCharge = getUpdatedChargeEntity(existingCharge, lifetimeUuid, appearance, charge)
-    var chargeRecord = existingCharge
+    var chargeRecord: ChargeEntity
     if (!existingCharge.isSame(updatedCharge, existingCharge.getLiveSentence() != null)) {
       val performedByUsername = charge.performedByUser ?: serviceUserService.getUsername()
       chargeRecord = createChargeRecordIfOverManyAppearancesOrUpdate(existingCharge, appearance, updatedCharge, performedByUsername) { charge ->
         charge.updateFrom(updatedCharge)
       }
-      entityChangeStatus = EntityChangeStatus.EDITED
+      eventsToEmit.add(
+        EventMetadataCreator.chargeEventMetadata(
+          appearance.courtCase.prisonerId,
+          appearance.courtCase.caseUniqueIdentifier,
+          appearance.appearanceUuid.toString(),
+          chargeRecord.chargeUuid.toString(),
+          EventType.CHARGE_UPDATED,
+          appearance.statusId == CourtAppearanceEntityStatus.FUTURE,
+        ),
+      )
     }
-    val courtCase = appearance.courtCase
-    return UpdateChargeInAppearanceTracking(entityChangeStatus, LegacyChargeCreatedResponse(lifetimeUuid, courtCase.caseUniqueIdentifier, courtCase.prisonerId), chargeRecord)
+    return RecordResponse(LegacyChargeCreatedResponse(lifetimeUuid, appearance.courtCase.caseUniqueIdentifier, appearance.courtCase.prisonerId), eventsToEmit)
   }
 
   private fun getUpdatedChargeEntity(existingCharge: ChargeEntity, lifetimeUuid: UUID, appearance: CourtAppearanceEntity, charge: LegacyUpdateCharge): ChargeEntity {
@@ -194,7 +215,7 @@ class LegacyChargeService(
   fun getChargeAtAppearance(appearanceLifetimeUuid: UUID, lifetimeUUID: UUID): LegacyCharge = LegacyCharge.from(getAtAppearanceUnlessDeleted(appearanceLifetimeUuid, lifetimeUUID))
 
   @Transactional
-  fun delete(chargeUUID: UUID, performedByUsername: String?): LegacyCharge? = chargeRepository.findByChargeUuid(chargeUUID)
+  fun delete(chargeUUID: UUID, performedByUsername: String?): MutableSet<EventMetadata>? = chargeRepository.findByChargeUuid(chargeUUID)
     .filter { it.statusId != ChargeEntityStatus.DELETED }
     .map { charge ->
       charge.delete(performedByUsername ?: serviceUserService.getUsername())
@@ -213,12 +234,21 @@ class LegacyChargeService(
       if (deletedManyChargesSentence != null) {
         legacySentenceService.handleManyChargesSentenceDeleted(deletedManyChargesSentence.sentenceUuid, performedByUsername ?: serviceUserService.getUsername())
       }
-      legacyCharge
+      mutableSetOf(
+        EventMetadataCreator.chargeEventMetadata(
+          legacyCharge.prisonerId,
+          legacyCharge.courtCaseUuid,
+          null,
+          legacyCharge.lifetimeUuid.toString(),
+          EventType.CHARGE_DELETED,
+          false,
+        ),
+      )
     }
 
   @Transactional
-  fun linkChargeToCase(appearanceUuid: UUID, chargeUuid: UUID, linkChargeToCase: LegacyLinkChargeToCase): Pair<EntityChangeStatus, LegacyChargeCreatedResponse> {
-    var entityChangeStatus = EntityChangeStatus.NO_CHANGE
+  fun linkChargeToCase(appearanceUuid: UUID, chargeUuid: UUID, linkChargeToCase: LegacyLinkChargeToCase): MutableSet<EventMetadata> {
+    val eventsToEmit = mutableSetOf<EventMetadata>()
     val existingCharge = getAtAppearanceUnlessDeleted(appearanceUuid, chargeUuid)
     val sourceCourtCase = courtCaseRepository.findByCaseUniqueIdentifier(linkChargeToCase.sourceCourtCaseUuid)?.takeUnless { it.statusId == CourtCaseEntityStatus.DELETED } ?: throw EntityNotFoundException("No court case found at ${linkChargeToCase.sourceCourtCaseUuid}")
     val appearance = existingCharge.appearanceCharges.first { it.appearance!!.appearanceUuid == appearanceUuid }.appearance!!
@@ -279,9 +309,18 @@ class LegacyChargeService(
           ChangeSource.NOMIS,
         ),
       )
-      entityChangeStatus = EntityChangeStatus.EDITED
+      eventsToEmit.add(
+        EventMetadataCreator.chargeEventMetadata(
+          appearance.courtCase.prisonerId,
+          appearance.courtCase.caseUniqueIdentifier,
+          appearance.appearanceUuid.toString(),
+          chargeUuid.toString(),
+          EventType.CHARGE_UPDATED,
+          appearance.statusId == CourtAppearanceEntityStatus.FUTURE,
+        ),
+      )
     }
-    return entityChangeStatus to LegacyChargeCreatedResponse(chargeUuid, appearance.courtCase.caseUniqueIdentifier, appearance.courtCase.prisonerId)
+    return eventsToEmit
   }
 
   private fun getAtAppearanceUnlessDeleted(appearanceUuid: UUID, chargeUuid: UUID): ChargeEntity = chargeRepository.findFirstByAppearanceChargesAppearanceAppearanceUuidAndChargeUuidAndStatusIdNotOrderByCreatedAtDesc(
@@ -297,10 +336,4 @@ class LegacyChargeService(
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
-
-  data class UpdateChargeInAppearanceTracking(
-    val entityChangeStatus: EntityChangeStatus,
-    val legacyChargeCreatedResponse: LegacyChargeCreatedResponse,
-    val chargeEntity: ChargeEntity,
-  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyCourtAppearanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyCourtAppearanceService.kt
@@ -212,6 +212,7 @@ class LegacyCourtAppearanceService(
             existingCourtAppearance.appearanceUuid.toString(),
             appearanceCharge.charge!!.chargeUuid.toString(),
             EventType.CHARGE_DELETED,
+            existingCourtAppearance.statusId == CourtAppearanceEntityStatus.FUTURE,
           ),
         )
       }
@@ -287,6 +288,7 @@ class LegacyCourtAppearanceService(
             existingCourtAppearance.appearanceUuid.toString(),
             existingCharge.chargeUuid.toString(),
             EventType.CHARGE_DELETED,
+            existingCourtAppearance.statusId == CourtAppearanceEntityStatus.FUTURE,
           ),
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyCourtCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyCourtCaseService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.audit
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.entity.audit.CourtCaseHistoryEntity
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ChangeSource
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ChargeEntityStatus
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtAppearanceEntityStatus
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtCaseEntityStatus
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.CourtCaseRepository
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.audit.ChargeHistoryRepository
@@ -24,7 +25,6 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controlle
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyLinkCase
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyUnlinkCase
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.reconciliation.ReconciliationCourtCase
-import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.domain.UnlinkEventsToEmit
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ServiceUserService
 import java.time.LocalDate
 import java.time.ZonedDateTime
@@ -104,10 +104,9 @@ class LegacyCourtCaseService(
   }
 
   @Transactional
-  fun unlinkCourtCases(sourceCourtCaseUuid: String, targetCourtCaseUuid: String, unlinkCase: LegacyUnlinkCase?): UnlinkEventsToEmit {
+  fun unlinkCourtCases(sourceCourtCaseUuid: String, targetCourtCaseUuid: String, unlinkCase: LegacyUnlinkCase?): MutableSet<EventMetadata> {
     val sourceCourtCase = getUnlessDeleted(sourceCourtCaseUuid)
-    var courtCaseEventMetadata: EventMetadata? = null
-    var chargeEventsToEmit: List<EventMetadata>
+    val eventsToEmit = mutableSetOf<EventMetadata>()
     val performedByUsername = unlinkCase?.performedByUser ?: serviceUserService.getUsername()
     if (sourceCourtCase.statusId != CourtCaseEntityStatus.ACTIVE || sourceCourtCase.mergedToCase != null) {
       sourceCourtCase.statusId = CourtCaseEntityStatus.ACTIVE
@@ -115,10 +114,12 @@ class LegacyCourtCaseService(
       sourceCourtCase.mergedToDate = null
       sourceCourtCase.updatedAt = ZonedDateTime.now()
       sourceCourtCase.updatedBy = performedByUsername
-      courtCaseEventMetadata = EventMetadataCreator.courtCaseEventMetadata(
-        sourceCourtCase.prisonerId,
-        sourceCourtCase.caseUniqueIdentifier,
-        EventType.COURT_CASE_UPDATED,
+      eventsToEmit.add(
+        EventMetadataCreator.courtCaseEventMetadata(
+          sourceCourtCase.prisonerId,
+          sourceCourtCase.caseUniqueIdentifier,
+          EventType.COURT_CASE_UPDATED,
+        ),
       )
       courtCaseHistoryRepository.save(
         CourtCaseHistoryEntity.from(
@@ -127,31 +128,34 @@ class LegacyCourtCaseService(
         ),
       )
     }
-    chargeEventsToEmit = sourceCourtCase.appearances.filter { it.appearanceCharges.any { appearanceCharge -> appearanceCharge.charge!!.statusId == ChargeEntityStatus.MERGED } }
-      .flatMap { appearance ->
-        appearance.appearanceCharges.filter { appearanceCharge -> appearanceCharge.charge!!.statusId == ChargeEntityStatus.MERGED }
-          .map { appearanceCharge ->
-            val charge = appearanceCharge.charge!!
-            charge.statusId = ChargeEntityStatus.ACTIVE
-            charge.updatedAt = ZonedDateTime.now()
-            charge.updatedBy = performedByUsername
-            chargeHistoryRepository.save(
-              ChargeHistoryEntity.from(
-                charge,
-                ChangeSource.NOMIS,
-              ),
-            )
-            EventMetadataCreator.chargeEventMetadata(
-              sourceCourtCase.prisonerId,
-              sourceCourtCase.caseUniqueIdentifier,
-              appearance.appearanceUuid.toString(),
-              charge.chargeUuid.toString(),
-              EventType.CHARGE_UPDATED,
-            )
-          }
-      }
+    eventsToEmit.addAll(
+      sourceCourtCase.appearances.filter { it.appearanceCharges.any { appearanceCharge -> appearanceCharge.charge!!.statusId == ChargeEntityStatus.MERGED } }
+        .flatMap { appearance ->
+          appearance.appearanceCharges.filter { appearanceCharge -> appearanceCharge.charge!!.statusId == ChargeEntityStatus.MERGED }
+            .map { appearanceCharge ->
+              val charge = appearanceCharge.charge!!
+              charge.statusId = ChargeEntityStatus.ACTIVE
+              charge.updatedAt = ZonedDateTime.now()
+              charge.updatedBy = performedByUsername
+              chargeHistoryRepository.save(
+                ChargeHistoryEntity.from(
+                  charge,
+                  ChangeSource.NOMIS,
+                ),
+              )
+              EventMetadataCreator.chargeEventMetadata(
+                sourceCourtCase.prisonerId,
+                sourceCourtCase.caseUniqueIdentifier,
+                appearance.appearanceUuid.toString(),
+                charge.chargeUuid.toString(),
+                EventType.CHARGE_UPDATED,
+                appearance.statusId == CourtAppearanceEntityStatus.FUTURE,
+              )
+            }
+        },
+    )
 
-    return UnlinkEventsToEmit(courtCaseEventMetadata, chargeEventsToEmit)
+    return eventsToEmit
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyDomainEventService.kt
@@ -52,6 +52,7 @@ class LegacyDomainEventService(
             eventMetaData.courtCaseId!!,
             eventMetaData.courtAppearanceId!!,
             EventSource.NOMIS,
+            eventMetaData.isOnFutureAppearance!!,
           )
           EventType.CHARGE_UPDATED -> chargeDomainEventService.update(
             eventMetaData.prisonerId,
@@ -59,12 +60,14 @@ class LegacyDomainEventService(
             eventMetaData.courtAppearanceId!!,
             eventMetaData.courtCaseId!!,
             EventSource.NOMIS,
+            eventMetaData.isOnFutureAppearance!!,
           )
           EventType.CHARGE_DELETED -> chargeDomainEventService.delete(
             eventMetaData.prisonerId,
             eventMetaData.chargeId!!,
             eventMetaData.courtCaseId!!,
             EventSource.NOMIS,
+            eventMetaData.isOnFutureAppearance!!,
           )
           EventType.COURT_APPEARANCE_INSERTED -> courtAppearanceDomainEventService.create(
             eventMetaData.prisonerId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyPrisonerMergeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyPrisonerMergeService.kt
@@ -431,7 +431,7 @@ class LegacyPrisonerMergeService(
         tracking,
         referenceData,
         mergeCreateCourtAppearance.eventId,
-        MergeHierarchyData(tracking.retainedPrisonerNumber, createdCourtCase.caseUniqueIdentifier, createdAppearance.appearanceUuid.toString()),
+        MergeHierarchyData(tracking.retainedPrisonerNumber, createdCourtCase.caseUniqueIdentifier, createdAppearance.appearanceUuid.toString(), createdAppearance.statusId == CourtAppearanceEntityStatus.FUTURE),
       )
     }
     charges.forEach { charge ->
@@ -477,6 +477,7 @@ class LegacyPrisonerMergeService(
         mergeHierarchyData.courtAppearanceId,
         createdCharge.chargeUuid.toString(),
         EventType.CHARGE_INSERTED,
+        mergeHierarchyData.isFutureCourtAppearance,
       ),
     )
     return createdCharge
@@ -628,6 +629,7 @@ class LegacyPrisonerMergeService(
     var prisonerId: String,
     var courtCaseId: String,
     var courtAppearanceId: String,
+    var isFutureCourtAppearance: Boolean,
     var chargeId: String? = null,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/ChargeDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/ChargeDomainEventService.kt
@@ -16,35 +16,35 @@ class ChargeDomainEventService(
   @Value("\${court.charge.getByIdPath}") private val courtChargeLookupPath: String,
 ) {
 
-  fun create(prisonerId: String, chargeId: String, courtCaseId: String, courtAppearanceId: String, source: EventSource) {
+  fun create(prisonerId: String, chargeId: String, courtCaseId: String, courtAppearanceId: String, source: EventSource, isOnFutureAppearance: Boolean) {
     snsService.publishDomainEvent(
       "charge.inserted",
       "Charge inserted",
       generateDetailsUri(courtChargeLookupPath, chargeId),
       ZonedDateTime.now(),
-      HmppsCourtChargeMessage(chargeId, courtCaseId, source, courtAppearanceId),
+      HmppsCourtChargeMessage(chargeId, courtCaseId, source, courtAppearanceId, isOnFutureAppearance),
       PersonReference(listOf(PersonReferenceType("NOMS", prisonerId))),
     )
   }
 
-  fun update(prisonerId: String, chargeId: String, courtAppearanceId: String, courtCaseId: String, source: EventSource) {
+  fun update(prisonerId: String, chargeId: String, courtAppearanceId: String, courtCaseId: String, source: EventSource, isOnFutureAppearance: Boolean) {
     snsService.publishDomainEvent(
       "charge.updated",
       "Charge updated",
       generateDetailsUri(courtChargeLookupPath, chargeId),
       ZonedDateTime.now(),
-      HmppsCourtChargeMessage(chargeId, courtCaseId, source, courtAppearanceId),
+      HmppsCourtChargeMessage(chargeId, courtCaseId, source, courtAppearanceId, isOnFutureAppearance),
       PersonReference(listOf(PersonReferenceType("NOMS", prisonerId))),
     )
   }
 
-  fun delete(prisonerId: String, chargeId: String, courtCaseId: String, source: EventSource) {
+  fun delete(prisonerId: String, chargeId: String, courtCaseId: String, source: EventSource, isOnFutureAppearance: Boolean) {
     snsService.publishDomainEvent(
       "charge.deleted",
       "Charge deleted",
       generateDetailsUri(courtChargeLookupPath, chargeId),
       ZonedDateTime.now(),
-      HmppsCourtChargeMessage(chargeId, courtCaseId, source),
+      HmppsCourtChargeMessage(chargeId, courtCaseId, source, null, isOnFutureAppearance),
       PersonReference(listOf(PersonReferenceType("NOMS", prisonerId))),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/ChargeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/ChargeService.kt
@@ -66,6 +66,7 @@ class ChargeService(
         courtAppearanceUuid.toString(),
         savedCharge.chargeUuid.toString(),
         EventType.CHARGE_INSERTED,
+        false,
       ),
     )
     charge.sentence?.let { createSentence ->
@@ -211,6 +212,7 @@ class ChargeService(
             courtAppearance.appearanceUuid.toString(),
             record.chargeUuid.toString(),
             EventType.CHARGE_UPDATED,
+            courtAppearance.statusId == CourtAppearanceEntityStatus.FUTURE,
           ),
         )
       } else if (chargeChangeStatus == EntityChangeStatus.CREATED) {
@@ -221,6 +223,7 @@ class ChargeService(
             courtAppearance.appearanceUuid.toString(),
             record.chargeUuid.toString(),
             EventType.CHARGE_INSERTED,
+            courtAppearance.statusId == CourtAppearanceEntityStatus.FUTURE,
           ),
         )
       }
@@ -282,6 +285,7 @@ class ChargeService(
         courtAppearance.appearanceUuid.toString(),
         savedCharge.chargeUuid.toString(),
         EventType.CHARGE_UPDATED,
+        true,
       ),
     )
     return RecordResponse(savedCharge, eventsToEmit)
@@ -327,6 +331,7 @@ class ChargeService(
           null,
           charge.chargeUuid.toString(),
           EventType.CHARGE_DELETED,
+          false,
         ),
       )
       chargeHistoryRepository.save(ChargeHistoryEntity.from(charge, ChangeSource.DPS))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/DpsDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/DpsDomainEventService.kt
@@ -46,6 +46,7 @@ class DpsDomainEventService(
             eventMetaData.courtCaseId!!,
             eventMetaData.courtAppearanceId!!,
             EventSource.DPS,
+            eventMetaData.isOnFutureAppearance!!,
           )
           EventType.CHARGE_UPDATED -> chargeDomainEventService.update(
             eventMetaData.prisonerId,
@@ -53,12 +54,14 @@ class DpsDomainEventService(
             eventMetaData.courtAppearanceId!!,
             eventMetaData.courtCaseId!!,
             EventSource.DPS,
+            eventMetaData.isOnFutureAppearance!!,
           )
           EventType.CHARGE_DELETED -> chargeDomainEventService.delete(
             eventMetaData.prisonerId,
             eventMetaData.chargeId!!,
             eventMetaData.courtCaseId!!,
             EventSource.DPS,
+            eventMetaData.isOnFutureAppearance!!,
           )
           EventType.COURT_APPEARANCE_INSERTED -> courtAppearanceDomainEventService.create(
             eventMetaData.prisonerId,


### PR DESCRIPTION
I've ended up having to refactor legacy methods to return `eventsToEmit` then use the `LegacyDomainEventService` to emit the events instead of using individual `<entity>EventService` to emit them.

There are other instances where `LegacyDomainEventService` is not used. I will raise a tech debt item to migrate some more methods to use that service