### PR TITLE
RASS-2348 Unlink UAL when a DPS recall is deleted via the NOMIS legacy-sentence delete path

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceService.kt
@@ -540,6 +540,9 @@ class LegacySentenceService(
       if (recallSentenceCount == 1L) {
         recall.delete(performedByUser)
         recallHistoryRepository.save(RecallHistoryEntity.from(recall, ChangeSource.NOMIS))
+        if (recall.source == DPS) {
+          adjustmentsApiClient.unlinkRecallAdjustments(recall.recallUuid)
+        }
 
         eventMetaDataList.add(
           EventMetadataCreator.recallEventMetadata(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/sentence/LegacyDeleteSentenceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/sentence/LegacyDeleteSentenceTests.kt
@@ -98,6 +98,7 @@ class LegacyDeleteSentenceTests : IntegrationTestBase() {
     val (sentenceOne, sentenceTwo) = createCourtCaseTwoSentences()
     adjustmentsApi.stubAllowCreateAdjustments()
     adjustmentsApi.stubGetAdjustmentsDefaultToNone()
+    adjustmentsApi.stubAllowUnlinkRecallAdjustments()
     val createdRecall = createRecall(
       DpsDataCreator.dpsCreateRecall(
         sentenceIds = listOf(sentenceOne.sentenceUuid, sentenceTwo.sentenceUuid),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/wiremock/AdjustmentsApiExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/wiremock/AdjustmentsApiExtension.kt
@@ -114,6 +114,11 @@ class AdjustmentsApiMockServer : WireMockServer(WireMockConfiguration.options().
       ),
   )
 
+  fun stubAllowUnlinkRecallAdjustments(): StubMapping = stubFor(
+    post(urlPathMatching("/adjustments/recall/.+/unlink"))
+      .willReturn(aResponse().withStatus(200)),
+  )
+
   fun verifyAdjustmentCreated(adjustment: AdjustmentDto) {
     verify(
       postRequestedFor(urlPathEqualTo("/adjustments")).withRequestBody(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceServiceTests.kt
@@ -283,7 +283,7 @@ class LegacySentenceServiceTests {
     val chargeUuid = UUID.randomUUID()
     val appearanceUuid = UUID.randomUUID()
 
-    val (existingSentence, recall) = getSentenceAndRecall(
+    val (existingSentence, nomisSourcedRecall) = getSentenceAndRecall(
       sentenceUuid = sentenceUuid,
       chargeUuid = chargeUuid,
       appearanceUuid = appearanceUuid,
@@ -293,7 +293,7 @@ class LegacySentenceServiceTests {
 
     every { sentenceHistoryRepository.save(any()) } returns mockk<SentenceHistoryEntity>(relaxed = true)
     every { recallHistoryRepository.save(any()) } returns mockk<RecallHistoryEntity>(relaxed = true)
-    every { recallSentenceRepository.countByRecallId(recall.id) } returns 1L
+    every { recallSentenceRepository.countByRecallId(nomisSourcedRecall.id) } returns 1L
 
     val recallHistorySlot = slot<RecallHistoryEntity>()
 
@@ -306,14 +306,41 @@ class LegacySentenceServiceTests {
     assertThat(recallHistorySlot.captured.status).isEqualTo(RecallEntityStatus.DELETED)
     assertThat(events).containsExactly(
       EventMetadataCreator.recallEventMetadata(
-        prisonerId = recall.prisonerId,
-        recallId = recall.recallUuid.toString(),
+        prisonerId = nomisSourcedRecall.prisonerId,
+        recallId = nomisSourcedRecall.recallUuid.toString(),
         sentenceIds = listOf(sentenceUuid.toString()),
         previousSentenceIds = emptyList(),
         previousRecallId = null,
         eventType = EventType.RECALL_DELETED,
       ),
     )
+    verify(exactly = 0) { adjustmentsApiClient.unlinkRecallAdjustments(any()) }
+  }
+
+  @Test
+  fun `delete unlinks recall UAL when latest recall from DPS source and deleted via NOMIS`() {
+    val sentenceUuid = UUID.randomUUID()
+    val chargeUuid = UUID.randomUUID()
+    val appearanceUuid = UUID.randomUUID()
+    val recallUuid = UUID.randomUUID()
+
+    val (existingSentence, _) = getSentenceAndRecall(
+      sentenceUuid = sentenceUuid,
+      chargeUuid = chargeUuid,
+      appearanceUuid = appearanceUuid,
+      recallType = RecallType.FTR_14,
+      existingRtc = LocalDate.of(2024, 1, 11),
+      recallUuid = recallUuid,
+      recallSource = EventSource.DPS,
+    )
+
+    every { sentenceHistoryRepository.save(any()) } returns mockk<SentenceHistoryEntity>(relaxed = true)
+    every { recallHistoryRepository.save(any()) } returns mockk<RecallHistoryEntity>(relaxed = true)
+    every { recallSentenceRepository.countByRecallId(any()) } returns 1L
+
+    service.delete(existingSentence, "SYNC_USER")
+
+    verify(exactly = 1) { adjustmentsApiClient.unlinkRecallAdjustments(recallUuid) }
   }
 
   @Test


### PR DESCRIPTION
This is a edge case scenario, where the user creates a recall in DPS and then deletes all the sentences via NOMIS.

Not expected to happen very often (best practice and advice is to delete via DPS)