### PR TITLE
Preserve charge aggravating factors across legacy charge updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyBaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyBaseService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ChangeS
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.ChargeRepository
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.audit.AppearanceChargeHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.repository.audit.ChargeHistoryRepository
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.AggravatingFactorsService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ServiceUserService
 
 abstract class LegacyBaseService(
@@ -16,6 +17,7 @@ abstract class LegacyBaseService(
   protected val appearanceChargeHistoryRepository: AppearanceChargeHistoryRepository,
   protected val chargeHistoryRepository: ChargeHistoryRepository,
   protected val serviceUserService: ServiceUserService,
+  protected val aggravatingFactorsService: AggravatingFactorsService,
 ) {
 
   fun createChargeRecordIfOverManyAppearancesOrUpdate(existingCharge: ChargeEntity, appearance: CourtAppearanceEntity, updatedCharge: ChargeEntity, performedByUsername: String, chargeModifyFunction: (ChargeEntity) -> Unit = {}): ChargeEntity {
@@ -40,6 +42,7 @@ abstract class LegacyBaseService(
         }
 
       chargeRecord = chargeRepository.save(updatedCharge)
+      aggravatingFactorsService.replaceAggravatingFactors(chargeRecord, chargeRecord.chargeAggravatingFactors.map { it.aggravatingFactor.code }.toSet())
       val appearanceCharge = AppearanceChargeEntity(
         appearance,
         chargeRecord,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyChargeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacyChargeService.kt
@@ -31,10 +31,10 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controlle
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyLinkChargeToCase
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyUpdateCharge
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyUpdateWholeCharge
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.AggravatingFactorsService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ServiceUserService
 import java.time.ZonedDateTime
 import java.util.UUID
-import kotlin.toString
 
 @Service
 class LegacyChargeService(
@@ -46,7 +46,8 @@ class LegacyChargeService(
   appearanceChargeHistoryRepository: AppearanceChargeHistoryRepository,
   private val legacySentenceService: LegacySentenceService,
   private val courtCaseRepository: CourtCaseRepository,
-) : LegacyBaseService(chargeRepository, appearanceChargeHistoryRepository, chargeHistoryRepository, serviceUserService) {
+  aggravatingFactorsService: AggravatingFactorsService,
+) : LegacyBaseService(chargeRepository, appearanceChargeHistoryRepository, chargeHistoryRepository, serviceUserService, aggravatingFactorsService) {
 
   @Transactional
   fun create(charge: LegacyCreateCharge): RecordResponse<LegacyChargeCreatedResponse> {
@@ -130,6 +131,7 @@ class LegacyChargeService(
     if (existingCourtAppearance.appearanceCharges.none { it.charge!!.chargeUuid == chargeUuid }) {
       val existingCharge = getUnlessDeleted(chargeUuid)
       val chargeEntity = chargeRepository.save(getUpdatedChargeEntity(existingCharge, chargeUuid, existingCourtAppearance, charge))
+      aggravatingFactorsService.replaceAggravatingFactors(chargeEntity, chargeEntity.chargeAggravatingFactors.map { it.aggravatingFactor.code }.toSet())
 
       val appearanceCharge = AppearanceChargeEntity(
         existingCourtAppearance,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceService.kt
@@ -55,6 +55,7 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controlle
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacySentenceCreatedResponse
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacySentenceDeletedResponse
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.RecallSentenceLegacyData
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.AggravatingFactorsService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ServiceUserService
 import java.time.ZonedDateTime
 import java.util.*
@@ -78,7 +79,8 @@ class LegacySentenceService(
   private val recallHistoryRepository: RecallHistoryRepository,
   private val recallSentenceHistoryRepository: RecallSentenceHistoryRepository,
   private val adjustmentsApiClient: AdjustmentsApiClient,
-) : LegacyBaseService(chargeRepository, appearanceChargeHistoryRepository, chargeHistoryRepository, serviceUserService) {
+  aggravatingFactorsService: AggravatingFactorsService,
+) : LegacyBaseService(chargeRepository, appearanceChargeHistoryRepository, chargeHistoryRepository, serviceUserService, aggravatingFactorsService) {
 
   @Transactional
   fun create(sentence: LegacyCreateSentence): RecordResponse<LegacySentenceCreatedResponse> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/charge/LegacyUpdateChargeInAppearanceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/charge/LegacyUpdateChargeInAppearanceTests.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.charge
 
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.courtappearance.ChargeAggravatingFactorHelper
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.DataCreator
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacyCourtAppearanceCreatedResponse
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.MigrationCreateCourtCasesResponse
@@ -14,6 +18,10 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 class LegacyUpdateChargeInAppearanceTests : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var jdbcTemplate: NamedParameterJdbcTemplate
+  private val aggravatingFactors by lazy { ChargeAggravatingFactorHelper(jdbcTemplate) }
 
   @Test
   fun `update charge in existing court appearance`() {
@@ -229,5 +237,69 @@ class LegacyUpdateChargeInAppearanceTests : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isForbidden
+  }
+
+  @Test
+  fun `should preserve OATC aggravating factor on single appearance charge`() {
+    val dpsCharge = DpsDataCreator.dpsCreateCharge(terrorRelated = true, foreignPowerRelated = null, sentence = null)
+    val appearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    createCourtCase(DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance)))
+
+    val legacyUpdate = DataCreator.legacyUpdateCharge(offenceStartDate = LocalDate.now().minusDays(5))
+    webTestClient.put()
+      .uri("/legacy/charge/${dpsCharge.chargeUuid}/appearance/${appearance.appearanceUuid}")
+      .bodyValue(legacyUpdate)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_CHARGE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus().isNoContent
+
+    assertThat(aggravatingFactors.countAggravatingFactor(dpsCharge.chargeUuid, "OATC")).isEqualTo(1)
+    assertThat(aggravatingFactors.countAggravatingFactor(dpsCharge.chargeUuid, "OAFPC")).isEqualTo(0)
+  }
+
+  @Test
+  fun `should preserve OAFPC aggravating factor on single appearance charge`() {
+    val dpsCharge = DpsDataCreator.dpsCreateCharge(terrorRelated = null, foreignPowerRelated = true, sentence = null)
+    val appearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    createCourtCase(DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance)))
+
+    val legacyUpdate = DataCreator.legacyUpdateCharge(offenceStartDate = LocalDate.now().minusDays(5))
+    webTestClient.put()
+      .uri("/legacy/charge/${dpsCharge.chargeUuid}/appearance/${appearance.appearanceUuid}")
+      .bodyValue(legacyUpdate)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_CHARGE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus().isNoContent
+
+    assertThat(aggravatingFactors.countAggravatingFactor(dpsCharge.chargeUuid, "OATC")).isEqualTo(0)
+    assertThat(aggravatingFactors.countAggravatingFactor(dpsCharge.chargeUuid, "OAFPC")).isEqualTo(1)
+  }
+
+  @Test
+  fun `should preserve on charge in multiple appearances aggravating factors on new charge record`() {
+    val dpsCharge = DpsDataCreator.dpsCreateCharge(terrorRelated = true, foreignPowerRelated = true, sentence = null)
+    val firstAppearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    val secondAppearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    createCourtCase(DpsDataCreator.dpsCreateCourtCase(appearances = listOf(firstAppearance, secondAppearance)))
+
+    val legacyUpdate = DataCreator.legacyUpdateCharge(offenceStartDate = LocalDate.now().minusDays(5))
+    webTestClient.put()
+      .uri("/legacy/charge/${dpsCharge.chargeUuid}/appearance/${secondAppearance.appearanceUuid}")
+      .bodyValue(legacyUpdate)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_CHARGE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus().isNoContent
+
+    assertThat(aggravatingFactors.countAggravatingFactorForLatestCharge("OATC")).isEqualTo(1)
+    assertThat(aggravatingFactors.countAggravatingFactorForLatestCharge("OAFPC")).isEqualTo(1)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/charge/LegacyUpdateChargeTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/charge/LegacyUpdateChargeTests.kt
@@ -1,17 +1,25 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.charge
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.CourtCase
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.CreateCourtCaseResponse
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.courtappearance.ChargeAggravatingFactorHelper
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.DataCreator
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCreator
 import java.time.LocalDate
 import java.util.UUID
 
 class LegacyUpdateChargeTests : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var jdbcTemplate: NamedParameterJdbcTemplate
+  private val aggravatingFactors by lazy { ChargeAggravatingFactorHelper(jdbcTemplate) }
 
   @Test
   fun `update charge in all court appearances`() {
@@ -151,5 +159,27 @@ class LegacyUpdateChargeTests : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isForbidden
+  }
+
+  @Test
+  fun `should preserve aggravating factors when terrorRelated already set on charge`() {
+    val dpsCharge = DpsDataCreator.dpsCreateCharge(terrorRelated = true, foreignPowerRelated = null, sentence = null)
+    val appearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    createCourtCase(DpsDataCreator.dpsCreateCourtCase(appearances = listOf(appearance)))
+
+    val toUpdate = DataCreator.legacyUpdateWholeCharge(offenceCode = "UPDATEDCODE")
+    webTestClient
+      .put()
+      .uri("/legacy/charge/${dpsCharge.chargeUuid}")
+      .bodyValue(toUpdate)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_CHARGE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus().isNoContent
+
+    assertThat(aggravatingFactors.countAggravatingFactor(dpsCharge.chargeUuid, "OATC")).isEqualTo(1)
+    assertThat(aggravatingFactors.countAggravatingFactor(dpsCharge.chargeUuid, "OAFPC")).isEqualTo(0)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/courtappearance/LegacyLinkChargesToCaseTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/courtappearance/LegacyLinkChargesToCaseTests.kt
@@ -1,14 +1,23 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.courtappearance
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.courtappearance.ChargeAggravatingFactorHelper
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.DataCreator
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.MigrationCreateCourtCasesResponse
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCreator
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 class LegacyLinkChargesToCaseTests : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var jdbcTemplate: NamedParameterJdbcTemplate
+  private val aggravatingFactors by lazy { ChargeAggravatingFactorHelper(jdbcTemplate) }
 
   @Test
   fun `links charge to source case`() {
@@ -159,5 +168,43 @@ class LegacyLinkChargesToCaseTests : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isForbidden
+  }
+
+  @Test
+  fun `should preserve aggravating factors when linking a charge to a source case`() {
+    val dpsCharge = DpsDataCreator.dpsCreateCharge(terrorRelated = true, foreignPowerRelated = true, sentence = null)
+    val sourceAppearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    val (sourceCourtCaseUuid, _) = createCourtCase(DpsDataCreator.dpsCreateCourtCase(appearances = listOf(sourceAppearance)))
+
+    val targetAppearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf())
+    createCourtCase(DpsDataCreator.dpsCreateCourtCase(appearances = listOf(targetAppearance)))
+
+    webTestClient
+      .put()
+      .uri("/legacy/court-appearance/${targetAppearance.appearanceUuid}/charge/${dpsCharge.chargeUuid}")
+      .bodyValue(DataCreator.legacyUpdateCharge())
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_APPEARANCE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    val linkChargeToCase = DataCreator.legacyLinkChargeToCase(sourceCourtCaseUuid)
+    webTestClient
+      .put()
+      .uri("/legacy/court-appearance/${targetAppearance.appearanceUuid}/charge/${dpsCharge.chargeUuid}/link")
+      .bodyValue(linkChargeToCase)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_APPEARANCE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    assertThat(aggravatingFactors.countAggravatingFactorForLatestCharge("OATC")).isEqualTo(1)
+    assertThat(aggravatingFactors.countAggravatingFactorForLatestCharge("OAFPC")).isEqualTo(1)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/courtappearance/LegacyLinkCourtAppearanceWithChargeTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/courtappearance/LegacyLinkCourtAppearanceWithChargeTests.kt
@@ -1,14 +1,22 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.courtappearance
 
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.courtappearance.ChargeAggravatingFactorHelper
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.DataCreator
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCreator
 import java.util.UUID
 
 class LegacyLinkCourtAppearanceWithChargeTests : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var jdbcTemplate: NamedParameterJdbcTemplate
+  private val aggravatingFactors by lazy { ChargeAggravatingFactorHelper(jdbcTemplate) }
 
   @Test
   fun `link existing appearance with existing charge`() {
@@ -131,5 +139,29 @@ class LegacyLinkCourtAppearanceWithChargeTests : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isForbidden
+  }
+
+  @Test
+  fun `should preserve aggravating factors when linking a charge with aggravating factors to an appearance`() {
+    val dpsCharge = DpsDataCreator.dpsCreateCharge(terrorRelated = true, foreignPowerRelated = true, sentence = null)
+    val firstAppearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    val secondAppearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf())
+    createCourtCase(DpsDataCreator.dpsCreateCourtCase(appearances = listOf(firstAppearance, secondAppearance)))
+
+    val toUpdateCharge = DataCreator.legacyUpdateCharge()
+    webTestClient
+      .put()
+      .uri("/legacy/court-appearance/${secondAppearance.appearanceUuid}/charge/${dpsCharge.chargeUuid}")
+      .bodyValue(toUpdateCharge)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_APPEARANCE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    assertThat(aggravatingFactors.countAggravatingFactorForLatestCharge("OATC")).isEqualTo(1)
+    assertThat(aggravatingFactors.countAggravatingFactorForLatestCharge("OAFPC")).isEqualTo(1)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/sentence/LegacyCreateSentenceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/legacy/sentence/LegacyCreateSentenceTests.kt
@@ -4,10 +4,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.everyItem
 import org.hamcrest.core.IsNull
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.event.EventSource
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.courtappearance.ChargeAggravatingFactorHelper
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.legacy.util.DataCreator
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.wiremock.AdjustmentsApiExtension.Companion.adjustmentsApi
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.RecallType
@@ -17,6 +20,10 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCrea
 import java.time.LocalDate
 
 class LegacyCreateSentenceTests : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var jdbcTemplate: NamedParameterJdbcTemplate
+  private val aggravatingFactors by lazy { ChargeAggravatingFactorHelper(jdbcTemplate) }
 
   @Test
   fun `create sentence in existing court case`() {
@@ -379,5 +386,32 @@ class LegacyCreateSentenceTests : IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isForbidden
+  }
+
+  @Test
+  fun `should preserve aggravating factors on new charge record when creating sentence on charge in multiple appearances`() {
+    val dpsCharge = DpsDataCreator.dpsCreateCharge(terrorRelated = true, foreignPowerRelated = true, sentence = null)
+    val firstAppearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    val secondAppearance = DpsDataCreator.dpsCreateCourtAppearance(charges = listOf(dpsCharge))
+    createCourtCase(DpsDataCreator.dpsCreateCourtCase(appearances = listOf(firstAppearance, secondAppearance)))
+
+    val legacySentence = DataCreator.legacyCreateSentence(
+      chargeUuids = listOf(dpsCharge.chargeUuid),
+      appearanceUuid = secondAppearance.appearanceUuid,
+    )
+    webTestClient
+      .post()
+      .uri("/legacy/sentence")
+      .bodyValue(legacySentence)
+      .headers {
+        it.authToken(roles = listOf("ROLE_REMAND_AND_SENTENCING_SENTENCE_RW"))
+        it.contentType = MediaType.APPLICATION_JSON
+      }
+      .exchange()
+      .expectStatus()
+      .isCreated
+
+    assertThat(aggravatingFactors.countAggravatingFactorForLatestCharge("OATC")).isEqualTo(1)
+    assertThat(aggravatingFactors.countAggravatingFactorForLatestCharge("OAFPC")).isEqualTo(1)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/legacy/service/LegacySentenceServiceTests.kt
@@ -49,6 +49,7 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controlle
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.LegacySentence
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.RecallSentenceLegacyData
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.legacy.controller.dto.SentenceLegacyData
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.AggravatingFactorsService
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.service.ServiceUserService
 import java.time.LocalDate
 import java.util.UUID
@@ -72,6 +73,7 @@ class LegacySentenceServiceTests {
   private val recallHistoryRepository: RecallHistoryRepository = mockk(relaxed = true)
   private val recallSentenceHistoryRepository: RecallSentenceHistoryRepository = mockk(relaxed = true)
   private val adjustmentsApiClient: AdjustmentsApiClient = mockk(relaxed = true)
+  private val aggravatingFactorsService: AggravatingFactorsService = mockk(relaxed = true)
 
   private val service = LegacySentenceService(
     sentenceRepository = sentenceRepository,
@@ -91,6 +93,7 @@ class LegacySentenceServiceTests {
     recallHistoryRepository = recallHistoryRepository,
     recallSentenceHistoryRepository = recallSentenceHistoryRepository,
     adjustmentsApiClient = adjustmentsApiClient,
+    aggravatingFactorsService = aggravatingFactorsService,
   )
 
   @Test


### PR DESCRIPTION
The chargeAggravatingFactors join entities still reference the previous record under some code paths, tests added to catch these paths and fixed with aggravatingFactorsService#replaceAggravatingFactors in appropriate places