### PR TITLE
RASS-2477 - Adding API validation to homeOfficeReferenceNumber

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/ImmigrationDetentionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/ImmigrationDetentionController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.persistence.EntityNotFoundException
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -49,7 +50,7 @@ class ImmigrationDetentionController(
   )
   @ResponseStatus(HttpStatus.CREATED)
   fun createImmigrationDetention(
-    @RequestBody createImmigrationDetention: CreateImmigrationDetention,
+    @Valid @RequestBody createImmigrationDetention: CreateImmigrationDetention,
   ): SaveImmigrationDetentionResponse = immigrationDetentionService.createImmigrationDetention(createImmigrationDetention).let { (response, eventsToEmit) ->
     dpsDomainEventService.emitEvents(eventsToEmit)
     response
@@ -143,7 +144,7 @@ class ImmigrationDetentionController(
   )
   @ResponseStatus(HttpStatus.OK)
   fun updateImmigrationDetention(
-    @RequestBody immigrationDetention: CreateImmigrationDetention,
+    @Valid @RequestBody immigrationDetention: CreateImmigrationDetention,
     @PathVariable immigrationDetentionUuid: UUID,
   ): SaveImmigrationDetentionResponse = immigrationDetentionService.updateImmigrationDetention(immigrationDetention, immigrationDetentionUuid)
     .let { (response, eventsToEmit) ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/CreateImmigrationDetention.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/dto/CreateImmigrationDetention.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto
 
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionNoLongerOfInterestType
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionRecordType
 import java.time.LocalDate
@@ -10,6 +12,8 @@ data class CreateImmigrationDetention(
   val appearanceOutcomeUuid: UUID,
   var immigrationDetentionRecordType: ImmigrationDetentionRecordType,
   var recordDate: LocalDate,
+  @field:Size(min = 5, max = 16, message = "The Home Office Reference Number should be between 5 and 16 characters.")
+  @field:Pattern(regexp = "^[A-Za-z0-9/]+$", message = "The Home Office Reference Number should contain only letters, numbers and '/'")
   var homeOfficeReferenceNumber: String? = null,
   var noLongerOfInterestReason: ImmigrationDetentionNoLongerOfInterestType? = null,
   var noLongerOfInterestComment: String? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/IntegrationTestBase.kt
@@ -526,7 +526,15 @@ abstract class IntegrationTestBase {
     .expectBody(DeleteRecallResponse::class.java)
     .returnResult().responseBody!!
 
-  protected fun createImmigrationDetention(immigrationDetention: CreateImmigrationDetention = DpsDataCreator.dpsCreateImmigrationDetention()) = webTestClient
+  protected fun createImmigrationDetention(immigrationDetention: CreateImmigrationDetention = DpsDataCreator.dpsCreateImmigrationDetention()) = createImmigrationDetentionExchange(
+    immigrationDetention,
+  )
+    .expectStatus()
+    .isCreated
+    .expectBody(SaveImmigrationDetentionResponse::class.java)
+    .returnResult().responseBody!!
+
+  protected fun createImmigrationDetentionExchange(immigrationDetention: CreateImmigrationDetention): WebTestClient.ResponseSpec = webTestClient
     .post()
     .uri("/immigration-detention")
     .bodyValue(immigrationDetention)
@@ -535,12 +543,20 @@ abstract class IntegrationTestBase {
       it.contentType = MediaType.APPLICATION_JSON
     }
     .exchange()
+
+  protected fun updateImmigrationDetention(immigrationDetention: CreateImmigrationDetention, uuid: UUID) = updateImmigrationDetentionExchange(
+    immigrationDetention,
+    uuid,
+  )
     .expectStatus()
-    .isCreated
+    .isOk
     .expectBody(SaveImmigrationDetentionResponse::class.java)
     .returnResult().responseBody!!
 
-  protected fun updateImmigrationDetention(immigrationDetention: CreateImmigrationDetention, uuid: UUID) = webTestClient
+  protected fun updateImmigrationDetentionExchange(
+    immigrationDetention: CreateImmigrationDetention,
+    uuid: UUID,
+  ): WebTestClient.ResponseSpec = webTestClient
     .put()
     .uri("/immigration-detention/$uuid")
     .bodyValue(immigrationDetention)
@@ -549,10 +565,6 @@ abstract class IntegrationTestBase {
       it.contentType = MediaType.APPLICATION_JSON
     }
     .exchange()
-    .expectStatus()
-    .isOk
-    .expectBody(SaveImmigrationDetentionResponse::class.java)
-    .returnResult().responseBody!!
 
   protected fun getImmigrationDetentionByUUID(immigrationDetentionUuid: UUID): ImmigrationDetention = webTestClient
     .get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/immigrationdetention/CreateImmigrationDetentionTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/immigrationdetention/CreateImmigrationDetentionTests.kt
@@ -2,13 +2,20 @@ package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.imm
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.ImmigrationDetention
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtAppearanceEntityStatus.IMMIGRATION_APPEARANCE
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.CourtCaseEntityStatus.INACTIVE
+import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionNoLongerOfInterestType.OTHER_REASON
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionRecordType.IS91
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionRecordType.NO_LONGER_OF_INTEREST
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCreator
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.*
@@ -172,5 +179,70 @@ class CreateImmigrationDetentionTests : IntegrationTestBase() {
     assertThat(messages).extracting<String> { it.eventType }
       .contains("court-case.inserted")
       .doesNotContain("court-case.updated")
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    "23423.444, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "-2342344, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "B12345B@, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "B12345B#, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "B12345B%, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "B12345B&, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "1233, The Home Office Reference Number should be between 5 and 16 characters.",
+    "0123456789ABCDEF1A, The Home Office Reference Number should be between 5 and 16 characters.",
+    "'', The Home Office Reference Number should be between 5 and 16 characters.",
+  )
+  fun `Should fail to create an Immigration Detention record based on invalid home office ref no`(
+    homeOfficeReferenceNumber: String?,
+    error: String,
+  ) {
+    val immigrationDetention = DpsDataCreator.dpsCreateImmigrationDetention(
+      prisonerId = "B12345BÍ",
+      immigrationDetentionRecordType = NO_LONGER_OF_INTEREST,
+      noLongerOfInterestReason = OTHER_REASON,
+      noLongerOfInterestComment = "A Comment",
+      recordDate = LocalDate.of(2021, 1, 1),
+      homeOfficeReferenceNumber = homeOfficeReferenceNumber,
+      createdByUsername = "aUser",
+      createdByPrison = "PRI",
+      appearanceOutcomeUuid = IMMIGRATION_NO_LONGER_OF_INTEREST_UUID,
+    )
+
+    // Act
+    createImmigrationDetentionExchange(immigrationDetention).expectStatus()
+      .isBadRequest.expectBody<ErrorResponse>().value { errorMessage ->
+        assertThat(errorMessage?.userMessage).contains("homeOfficeReferenceNumber: $error")
+      }
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(
+    strings = [
+      "23423444",
+      "2342344/",
+      "B123/45B",
+      "BBBBB",
+      "BBBBBBBBBBBBBBBC",
+      "12345",
+      "0123456789ABCDEF",
+    ],
+  )
+  fun `Should succeed in creating an Immigration Detention record based on valid home office ref no`(homeOfficeReferenceNumber: String?) {
+    val immigrationDetention = DpsDataCreator.dpsCreateImmigrationDetention(
+      prisonerId = "B12345BÍ",
+      immigrationDetentionRecordType = NO_LONGER_OF_INTEREST,
+      noLongerOfInterestReason = OTHER_REASON,
+      noLongerOfInterestComment = "A Comment",
+      recordDate = LocalDate.of(2021, 1, 1),
+      homeOfficeReferenceNumber = homeOfficeReferenceNumber,
+      createdByUsername = "aUser",
+      createdByPrison = "PRI",
+      appearanceOutcomeUuid = IMMIGRATION_NO_LONGER_OF_INTEREST_UUID,
+    )
+
+    // Act
+    createImmigrationDetentionExchange(immigrationDetention).expectStatus().isCreated
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/immigrationdetention/UpdateImmigrationDetentionTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/immigrationdetention/UpdateImmigrationDetentionTests.kt
@@ -2,6 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.imm
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.controller.dto.ImmigrationDetention
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.domain.event.EventSource.DPS
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.IntegrationTestBase
@@ -10,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.Immigra
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionRecordType.DEPORTATION_ORDER
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.jpa.enum.ImmigrationDetentionRecordType.NO_LONGER_OF_INTEREST
 import uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.util.DpsDataCreator
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.*
@@ -112,5 +118,72 @@ class UpdateImmigrationDetentionTests : IntegrationTestBase() {
           createdAt = ZonedDateTime.now(),
         ),
       )
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    "23423.444, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "-2342344, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "B12345B@, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "B12345B#, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "B12345B%, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "B12345B&, The Home Office Reference Number should contain only letters, numbers and '/'",
+    "1233, The Home Office Reference Number should be between 5 and 16 characters.",
+    "0123456789ABCDEF1A, The Home Office Reference Number should be between 5 and 16 characters.",
+    "'', The Home Office Reference Number should be between 5 and 16 characters.",
+  )
+  fun `Should fail to update an Immigration Detention record based on invalid home office ref no`(
+    homeOfficeReferenceNumber: String?,
+    error: String,
+  ) {
+    val immigrationDetention = DpsDataCreator.dpsCreateImmigrationDetention(
+      prisonerId = "B12345BÍ",
+      immigrationDetentionRecordType = NO_LONGER_OF_INTEREST,
+      noLongerOfInterestReason = OTHER_REASON,
+      noLongerOfInterestComment = "A Comment",
+      recordDate = LocalDate.of(2021, 1, 1),
+      homeOfficeReferenceNumber = homeOfficeReferenceNumber,
+      createdByUsername = "aUser",
+      createdByPrison = "PRI",
+      appearanceOutcomeUuid = IMMIGRATION_NO_LONGER_OF_INTEREST_UUID,
+    )
+    val uuid = UUID.randomUUID()
+
+    // Act
+    updateImmigrationDetentionExchange(immigrationDetention, uuid).expectStatus()
+      .isBadRequest.expectBody<ErrorResponse>().value { errorMessage ->
+        assertThat(errorMessage?.userMessage).contains("homeOfficeReferenceNumber: $error")
+      }
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(
+    strings = [
+      "23423444",
+      "2342344/",
+      "B123/45B",
+      "BBBBB",
+      "BBBBBBBBBBBBBBBC",
+      "12345",
+      "0123456789ABCDEF",
+    ],
+  )
+  fun `Should succeed in updating an Immigration Detention record based on valid home office ref no`(homeOfficeReferenceNumber: String?) {
+    val immigrationDetention = DpsDataCreator.dpsCreateImmigrationDetention(
+      prisonerId = "B12345BÍ",
+      immigrationDetentionRecordType = NO_LONGER_OF_INTEREST,
+      noLongerOfInterestReason = OTHER_REASON,
+      noLongerOfInterestComment = "A Comment",
+      recordDate = LocalDate.of(2021, 1, 1),
+      homeOfficeReferenceNumber = homeOfficeReferenceNumber,
+      createdByUsername = "aUser",
+      createdByPrison = "PRI",
+      appearanceOutcomeUuid = IMMIGRATION_NO_LONGER_OF_INTEREST_UUID,
+    )
+    val uuid = UUID.randomUUID()
+
+    // Act
+    updateImmigrationDetentionExchange(immigrationDetention, uuid).expectStatus().isOk
   }
 }


### PR DESCRIPTION
In harmony with the work carried out on the [Front End](https://dsdmoj.atlassian.net/jira/software/c/projects/RASS/boards/2690?assignee=712020%3A1fa3ca40-949f-4a52-ae69-cc214bce8277&selectedIssue=RASS-2384) this change protects the backend from direct api requests containing malformed homeOfficeReferenceNumber formatting