### PR TITLE
CDIA-266: Add case references to uploaded document metadata

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/client/DocumentManagementApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/client/DocumentManagementApiClient.kt
@@ -41,25 +41,26 @@ class DocumentManagementApiClient(@Qualifier("documentManagementApiWebClient") p
   fun updateDocumentMetadata(
     documentId: String,
     status: DocumentMetadataStatus,
-    caseReferences: Set<String>,
+    caseReference: String? = null,
   ) {
     webClient
       .patch()
       .uri("/documents/{documentId}/metadata", documentId)
       .header("Service-Name", "Remand and Sentencing")
-      .bodyValue(buildDocumentMetadataPath(status, caseReferences))
+      .bodyValue(buildDocumentMetadataPath(status, caseReference))
       .retrieve()
       .toBodilessEntity()
       .block()
   }
 
-  private fun buildDocumentMetadataPath(status: DocumentMetadataStatus, caseReferences: Set<String>): Map<String, Any> {
-    val baseMetadata = mutableMapOf<String, Any>(
+  private fun buildDocumentMetadataPath(status: DocumentMetadataStatus, caseReference: String? = null): Map<String, Any> {
+    val metadata = mutableMapOf<String, Any>(
       "status" to status,
       "isUnread" to false,
     )
-    caseReferences.takeIf { it.isNotEmpty() }?.let { baseMetadata["caseReferences"] = it.toList() }
-    return baseMetadata
+
+    caseReference.takeIf { !it.isNullOrBlank() }?.let { metadata["caseReferences"] = listOf(it) }
+    return metadata
   }
 
   fun getDocumentsByIds(documentIds: List<String>): List<DocumentManagementApiDocument> = webClient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/client/DocumentManagementApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/client/DocumentManagementApiClient.kt
@@ -18,6 +18,8 @@ class DocumentManagementApiClient(@Qualifier("documentManagementApiWebClient") p
       .toBodilessEntity()
       .block()
   }
+
+  @Deprecated("Use updateDocumentMetadata instead")
   fun setDocumentStatus(
     documentId: String,
     status: DocumentMetadataStatus,
@@ -34,6 +36,30 @@ class DocumentManagementApiClient(@Qualifier("documentManagementApiWebClient") p
       .retrieve()
       .toBodilessEntity()
       .block()
+  }
+
+  fun updateDocumentMetadata(
+    documentId: String,
+    status: DocumentMetadataStatus,
+    caseReferences: Set<String>,
+  ) {
+    webClient
+      .patch()
+      .uri("/documents/{documentId}/metadata", documentId)
+      .header("Service-Name", "Remand and Sentencing")
+      .bodyValue(buildDocumentMetadataPath(status, caseReferences))
+      .retrieve()
+      .toBodilessEntity()
+      .block()
+  }
+
+  private fun buildDocumentMetadataPath(status: DocumentMetadataStatus, caseReferences: Set<String>): Map<String, Any> {
+    val baseMetadata = mutableMapOf<String, Any>(
+      "status" to status,
+      "isUnread" to false,
+    )
+    caseReferences.takeIf { it.isNotEmpty() }?.let { baseMetadata["caseReferences"] = it.toList() }
+    return baseMetadata
   }
 
   fun getDocumentsByIds(documentIds: List<String>): List<DocumentManagementApiDocument> = webClient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtAppearanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtAppearanceController.kt
@@ -52,11 +52,7 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
-
-    // TODO (TANQ)
-    val caseReferences = updatedCourtCaseReferences?.caseReferences
-
-    uploadedDocumentService.setDocumentStatus(documentUpdates)
+    uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
     CreateCourtAppearanceResponse.from(appearance.appearanceUuid)
   } ?: throw EntityNotFoundException("No court case found at ${createCourtAppearance.courtCaseUuid}")
 
@@ -101,11 +97,7 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
-
-    // TODO (TANQ)
-    val caseReferences = updatedCourtCaseReferences?.caseReferences
-
-    uploadedDocumentService.setDocumentStatus(documentUpdates)
+    uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
     CreateCourtAppearanceResponse.from(appearance.appearanceUuid)
   } ?: throw EntityNotFoundException("No court case found at ${createCourtAppearance.courtCaseUuid}")
 
@@ -133,11 +125,7 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
         )
       }
       dpsDomainEventService.emitEvents(records.eventsToEmit)
-
-      // TODO (TANQ)
-      val caseReferences = updatedCourtCaseReferences?.caseReferences
-
-      uploadedDocumentService.setDocumentStatus(documentUpdates)
+      uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtAppearanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtAppearanceController.kt
@@ -45,12 +45,17 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
   )
   @ResponseStatus(HttpStatus.CREATED)
   fun createCourtAppearance(@RequestBody createCourtAppearance: CreateCourtAppearance): CreateCourtAppearanceResponse = courtAppearanceService.createCourtAppearance(createCourtAppearance)?.let { (appearance, eventsToEmit, documentUpdates) ->
-    courtCaseReferenceService.updateCourtCaseReferences(createCourtAppearance.courtCaseUuid!!)?.takeIf { it.hasUpdated }?.let {
+    val updatedCourtCaseReferences = courtCaseReferenceService.updateCourtCaseReferences(createCourtAppearance.courtCaseUuid!!)
+    updatedCourtCaseReferences?.takeIf { it.hasUpdated }?.let {
       eventsToEmit.add(
         EventMetadataCreator.courtCaseEventMetadata(it.prisonerId, it.courtCaseId, EventType.LEGACY_COURT_CASE_REFERENCES_UPDATED),
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
+
+    // TODO (TANQ)
+    val caseReferences = updatedCourtCaseReferences?.caseReferences
+
     uploadedDocumentService.setDocumentStatus(documentUpdates)
     CreateCourtAppearanceResponse.from(appearance.appearanceUuid)
   } ?: throw EntityNotFoundException("No court case found at ${createCourtAppearance.courtCaseUuid}")
@@ -89,12 +94,17 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
   )
   @ResponseStatus(HttpStatus.OK)
   fun updateCourtAppearance(@RequestBody createCourtAppearance: CreateCourtAppearance, @PathVariable appearanceUuid: UUID): CreateCourtAppearanceResponse = courtAppearanceService.createCourtAppearanceByAppearanceUuid(createCourtAppearance.copy(appearanceUuid = appearanceUuid), appearanceUuid)?.let { (appearance, eventsToEmit, documentUpdates) ->
-    courtCaseReferenceService.updateCourtCaseReferences(createCourtAppearance.courtCaseUuid!!)?.takeIf { it.hasUpdated }?.let {
+    val updatedCourtCaseReferences = courtCaseReferenceService.updateCourtCaseReferences(createCourtAppearance.courtCaseUuid!!)
+    updatedCourtCaseReferences?.takeIf { it.hasUpdated }?.let {
       eventsToEmit.add(
         EventMetadataCreator.courtCaseEventMetadata(it.prisonerId, it.courtCaseId, EventType.LEGACY_COURT_CASE_REFERENCES_UPDATED),
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
+
+    // TODO (TANQ)
+    val caseReferences = updatedCourtCaseReferences?.caseReferences
+
     uploadedDocumentService.setDocumentStatus(documentUpdates)
     CreateCourtAppearanceResponse.from(appearance.appearanceUuid)
   } ?: throw EntityNotFoundException("No court case found at ${createCourtAppearance.courtCaseUuid}")
@@ -116,12 +126,17 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
   @ResponseStatus(HttpStatus.NO_CONTENT)
   fun deleteCourtAppearance(@PathVariable appearanceUuid: UUID) {
     courtAppearanceService.delete(appearanceUuid).let { (records, courtCaseUuid, documentUpdates) ->
-      courtCaseReferenceService.updateCourtCaseReferences(courtCaseUuid)?.takeIf { it.hasUpdated }?.let {
+      val updatedCourtCaseReferences = courtCaseReferenceService.updateCourtCaseReferences(courtCaseUuid)
+      updatedCourtCaseReferences?.takeIf { it.hasUpdated }?.let {
         records.eventsToEmit.add(
           EventMetadataCreator.courtCaseEventMetadata(it.prisonerId, it.courtCaseId, EventType.LEGACY_COURT_CASE_REFERENCES_UPDATED),
         )
       }
       dpsDomainEventService.emitEvents(records.eventsToEmit)
+
+      // TODO (TANQ)
+      val caseReferences = updatedCourtCaseReferences?.caseReferences
+
       uploadedDocumentService.setDocumentStatus(documentUpdates)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtAppearanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtAppearanceController.kt
@@ -45,14 +45,13 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
   )
   @ResponseStatus(HttpStatus.CREATED)
   fun createCourtAppearance(@RequestBody createCourtAppearance: CreateCourtAppearance): CreateCourtAppearanceResponse = courtAppearanceService.createCourtAppearance(createCourtAppearance)?.let { (appearance, eventsToEmit, documentUpdates) ->
-    val updatedCourtCaseReferences = courtCaseReferenceService.updateCourtCaseReferences(createCourtAppearance.courtCaseUuid!!)
-    updatedCourtCaseReferences?.takeIf { it.hasUpdated }?.let {
+    courtCaseReferenceService.updateCourtCaseReferences(createCourtAppearance.courtCaseUuid!!)?.takeIf { it.hasUpdated }?.let {
       eventsToEmit.add(
         EventMetadataCreator.courtCaseEventMetadata(it.prisonerId, it.courtCaseId, EventType.LEGACY_COURT_CASE_REFERENCES_UPDATED),
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
-    uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
+    uploadedDocumentService.updateDocumentMetadata(documentUpdates)
     CreateCourtAppearanceResponse.from(appearance.appearanceUuid)
   } ?: throw EntityNotFoundException("No court case found at ${createCourtAppearance.courtCaseUuid}")
 
@@ -90,14 +89,13 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
   )
   @ResponseStatus(HttpStatus.OK)
   fun updateCourtAppearance(@RequestBody createCourtAppearance: CreateCourtAppearance, @PathVariable appearanceUuid: UUID): CreateCourtAppearanceResponse = courtAppearanceService.createCourtAppearanceByAppearanceUuid(createCourtAppearance.copy(appearanceUuid = appearanceUuid), appearanceUuid)?.let { (appearance, eventsToEmit, documentUpdates) ->
-    val updatedCourtCaseReferences = courtCaseReferenceService.updateCourtCaseReferences(createCourtAppearance.courtCaseUuid!!)
-    updatedCourtCaseReferences?.takeIf { it.hasUpdated }?.let {
+    courtCaseReferenceService.updateCourtCaseReferences(createCourtAppearance.courtCaseUuid!!)?.takeIf { it.hasUpdated }?.let {
       eventsToEmit.add(
         EventMetadataCreator.courtCaseEventMetadata(it.prisonerId, it.courtCaseId, EventType.LEGACY_COURT_CASE_REFERENCES_UPDATED),
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
-    uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
+    uploadedDocumentService.updateDocumentMetadata(documentUpdates)
     CreateCourtAppearanceResponse.from(appearance.appearanceUuid)
   } ?: throw EntityNotFoundException("No court case found at ${createCourtAppearance.courtCaseUuid}")
 
@@ -118,14 +116,13 @@ class CourtAppearanceController(private val courtAppearanceService: CourtAppeara
   @ResponseStatus(HttpStatus.NO_CONTENT)
   fun deleteCourtAppearance(@PathVariable appearanceUuid: UUID) {
     courtAppearanceService.delete(appearanceUuid).let { (records, courtCaseUuid, documentUpdates) ->
-      val updatedCourtCaseReferences = courtCaseReferenceService.updateCourtCaseReferences(courtCaseUuid)
-      updatedCourtCaseReferences?.takeIf { it.hasUpdated }?.let {
+      courtCaseReferenceService.updateCourtCaseReferences(courtCaseUuid)?.takeIf { it.hasUpdated }?.let {
         records.eventsToEmit.add(
           EventMetadataCreator.courtCaseEventMetadata(it.prisonerId, it.courtCaseId, EventType.LEGACY_COURT_CASE_REFERENCES_UPDATED),
         )
       }
       dpsDomainEventService.emitEvents(records.eventsToEmit)
-      uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
+      uploadedDocumentService.updateDocumentMetadata(documentUpdates)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
@@ -81,6 +81,10 @@ class CourtCaseController(
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
+
+    // TODO (TANQ)
+    val caseReferences = updatedCourtCaseReferences?.caseReferences
+
     uploadedDocumentService.setDocumentStatus(documentUpdates)
     return CreateCourtCaseResponse.from(courtCase.caseUniqueIdentifier, createCourtCase)
   }
@@ -112,6 +116,10 @@ class CourtCaseController(
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
+
+    // TODO (TANQ)
+    val caseReferences = updatedCourtCaseReferences?.caseReferences
+
     uploadedDocumentService.setDocumentStatus(documentUpdates)
     return CreateCourtCaseResponse.from(courtCaseUuid, createCourtCase)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
@@ -81,11 +81,7 @@ class CourtCaseController(
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
-
-    // TODO (TANQ)
-    val caseReferences = updatedCourtCaseReferences?.caseReferences
-
-    uploadedDocumentService.setDocumentStatus(documentUpdates)
+    uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
     return CreateCourtCaseResponse.from(courtCase.caseUniqueIdentifier, createCourtCase)
   }
 
@@ -116,11 +112,7 @@ class CourtCaseController(
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
-
-    // TODO (TANQ)
-    val caseReferences = updatedCourtCaseReferences?.caseReferences
-
-    uploadedDocumentService.setDocumentStatus(documentUpdates)
+    uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
     return CreateCourtCaseResponse.from(courtCaseUuid, createCourtCase)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/controller/CourtCaseController.kt
@@ -81,7 +81,7 @@ class CourtCaseController(
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
-    uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
+    uploadedDocumentService.updateDocumentMetadata(documentUpdates)
     return CreateCourtCaseResponse.from(courtCase.caseUniqueIdentifier, createCourtCase)
   }
 
@@ -112,7 +112,7 @@ class CourtCaseController(
       )
     }
     dpsDomainEventService.emitEvents(eventsToEmit)
-    uploadedDocumentService.updateDocumentMetadata(documentUpdates, updatedCourtCaseReferences?.caseReferences)
+    uploadedDocumentService.updateDocumentMetadata(documentUpdates)
     return CreateCourtCaseResponse.from(courtCaseUuid, createCourtCase)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/DocumentStatusUpdates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/DocumentStatusUpdates.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 data class DocumentStatusUpdates(
   val documentId: UUID,
   val status: DocumentMetadataStatus,
+  val caseReference: String? = null,
 )
 
 enum class DocumentMetadataStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/UpdatedCourtCaseReferences.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/UpdatedCourtCaseReferences.kt
@@ -7,5 +7,4 @@ data class UpdatedCourtCaseReferences(
   val courtCaseId: String,
   val timeUpdated: ZonedDateTime,
   val hasUpdated: Boolean,
-  val caseReferences: Set<String>? = emptySet(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/UpdatedCourtCaseReferences.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/domain/UpdatedCourtCaseReferences.kt
@@ -7,4 +7,5 @@ data class UpdatedCourtCaseReferences(
   val courtCaseId: String,
   val timeUpdated: ZonedDateTime,
   val hasUpdated: Boolean,
+  val caseReferences: Set<String>? = emptySet(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/UploadedDocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/UploadedDocumentService.kt
@@ -64,7 +64,7 @@ class UploadedDocumentService(
     }
 
     documentUUIDs.forEach {
-      documentStatusUpdates.add(DocumentStatusUpdates(it, DocumentMetadataStatus.ACTIVE))
+      documentStatusUpdates.add(DocumentStatusUpdates(it, DocumentMetadataStatus.ACTIVE, appearance.courtCaseReference))
     }
 
     return documentStatusUpdates
@@ -128,16 +128,13 @@ class UploadedDocumentService(
   }
 
   @Async
-  fun updateDocumentMetadata(
-    updates: List<DocumentStatusUpdates>,
-    caseReferences: Set<String>? = emptySet(),
-  ) {
+  fun updateDocumentMetadata(updates: List<DocumentStatusUpdates>) {
     updates.forEach { update ->
       try {
         documentManagementApiClient.updateDocumentMetadata(
           documentId = update.documentId.toString(),
           status = update.status,
-          caseReferences = caseReferences.takeIf { update.status == DocumentMetadataStatus.ACTIVE }.orEmpty(),
+          caseReference = update.caseReference.takeIf { update.status == DocumentMetadataStatus.ACTIVE },
         )
       } catch (e: Exception) {
         log.warn(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/UploadedDocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/UploadedDocumentService.kt
@@ -106,6 +106,7 @@ class UploadedDocumentService(
   }
 
   @Async
+  @Deprecated("Use updateDocumentMetadata instead")
   fun setDocumentStatus(
     updates: List<DocumentStatusUpdates>,
   ) {
@@ -114,6 +115,29 @@ class UploadedDocumentService(
         documentManagementApiClient.setDocumentStatus(
           documentId = update.documentId.toString(),
           status = update.status,
+        )
+      } catch (e: Exception) {
+        log.warn(
+          "Failed to update metadata for document {} with status {}",
+          update.documentId,
+          update.status,
+          e,
+        )
+      }
+    }
+  }
+
+  @Async
+  fun updateDocumentMetadata(
+    updates: List<DocumentStatusUpdates>,
+    caseReferences: Set<String>? = emptySet(),
+  ) {
+    updates.forEach { update ->
+      try {
+        documentManagementApiClient.updateDocumentMetadata(
+          documentId = update.documentId.toString(),
+          status = update.status,
+          caseReferences = caseReferences.takeIf { update.status == DocumentMetadataStatus.ACTIVE }.orEmpty(),
         )
       } catch (e: Exception) {
         log.warn(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/legacy/CourtCaseReferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/legacy/CourtCaseReferenceService.kt
@@ -65,7 +65,8 @@ class CourtCaseReferenceService(private val courtCaseRepository: CourtCaseReposi
     val toStoreCaseReferences = existingCaseReferences.filter { existingCaseReference -> allCaseRefsToRemove.none { toRemoveCaseReference -> toRemoveCaseReference.offenderCaseReference == existingCaseReference.offenderCaseReference } }
     courtCaseEntity.legacyData = CourtCaseLegacyData(toStoreCaseReferences.toMutableList(), courtCaseEntity.legacyData?.bookingId)
     courtCaseHistoryRepository.save(CourtCaseHistoryEntity.from(courtCaseEntity, ChangeSource.DPS))
-    return UpdatedCourtCaseReferences(courtCaseEntity.prisonerId, courtCaseEntity.caseUniqueIdentifier, ZonedDateTime.now(), (toAddCaseReferences.isNotEmpty() || toRemoveCaseReferences.isNotEmpty()) && courtCaseEntity.statusId != CourtCaseEntityStatus.DELETED)
+
+    return UpdatedCourtCaseReferences(courtCaseEntity.prisonerId, courtCaseEntity.caseUniqueIdentifier, ZonedDateTime.now(), hasCaseReferenceChanged(toAddCaseReferences, toRemoveCaseReferences, courtCaseEntity.statusId), getCaseReferences(toStoreCaseReferences))
   }
 
   @Transactional
@@ -84,4 +85,8 @@ class CourtCaseReferenceService(private val courtCaseRepository: CourtCaseReposi
       courtCaseHistoryRepository.save(CourtCaseHistoryEntity.from(courtCaseRepository.findByIdOrNull(courtCase.id)!!, ChangeSource.NOMIS))
     }
   }
+
+  private fun hasCaseReferenceChanged(toAddCaseReferences: List<CaseReferenceLegacyData>, toRemoveCaseReferences: List<CaseReferenceLegacyData>, courtCaseStatus: CourtCaseEntityStatus): Boolean = ((toAddCaseReferences.isNotEmpty() || toRemoveCaseReferences.isNotEmpty()) && courtCaseStatus != CourtCaseEntityStatus.DELETED)
+
+  private fun getCaseReferences(toStoreCaseReferences: List<CaseReferenceLegacyData>): Set<String> = toStoreCaseReferences.map { it.offenderCaseReference }.toSet()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/legacy/CourtCaseReferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/legacy/CourtCaseReferenceService.kt
@@ -65,8 +65,7 @@ class CourtCaseReferenceService(private val courtCaseRepository: CourtCaseReposi
     val toStoreCaseReferences = existingCaseReferences.filter { existingCaseReference -> allCaseRefsToRemove.none { toRemoveCaseReference -> toRemoveCaseReference.offenderCaseReference == existingCaseReference.offenderCaseReference } }
     courtCaseEntity.legacyData = CourtCaseLegacyData(toStoreCaseReferences.toMutableList(), courtCaseEntity.legacyData?.bookingId)
     courtCaseHistoryRepository.save(CourtCaseHistoryEntity.from(courtCaseEntity, ChangeSource.DPS))
-
-    return UpdatedCourtCaseReferences(courtCaseEntity.prisonerId, courtCaseEntity.caseUniqueIdentifier, ZonedDateTime.now(), hasCaseReferenceChanged(toAddCaseReferences, toRemoveCaseReferences, courtCaseEntity.statusId), getCaseReferences(toStoreCaseReferences))
+    return UpdatedCourtCaseReferences(courtCaseEntity.prisonerId, courtCaseEntity.caseUniqueIdentifier, ZonedDateTime.now(), hasCaseReferenceChanged(toAddCaseReferences, toRemoveCaseReferences, courtCaseEntity.statusId))
   }
 
   @Transactional
@@ -87,6 +86,4 @@ class CourtCaseReferenceService(private val courtCaseRepository: CourtCaseReposi
   }
 
   private fun hasCaseReferenceChanged(toAddCaseReferences: List<CaseReferenceLegacyData>, toRemoveCaseReferences: List<CaseReferenceLegacyData>, courtCaseStatus: CourtCaseEntityStatus): Boolean = ((toAddCaseReferences.isNotEmpty() || toRemoveCaseReferences.isNotEmpty()) && courtCaseStatus != CourtCaseEntityStatus.DELETED)
-
-  private fun getCaseReferences(toStoreCaseReferences: List<CaseReferenceLegacyData>): Set<String> = toStoreCaseReferences.map { it.offenderCaseReference }.toSet()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/IntegrationTestBase.kt
@@ -837,7 +837,7 @@ abstract class IntegrationTestBase {
     return documents
   }
 
-  protected fun verifyDocumentMetadataUpdated(documentUUID: UUID, status: String, caseReferences: List<String>? = emptyList()) {
+  protected fun verifyDocumentMetadataUpdated(documentUUID: UUID, status: String, caseReference: String? = null) {
     await untilAsserted {
       documentManagementApi.verify(
         WireMock.patchRequestedFor(WireMock.urlEqualTo("/documents/$documentUUID/metadata"))
@@ -845,7 +845,7 @@ abstract class IntegrationTestBase {
             WireMock.equalToJson(
               documentMetadataRequest(
                 status,
-                caseReferences?.joinToString(",") ?: "",
+                caseReference,
               ),
             ),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/IntegrationTestBase.kt
@@ -837,7 +837,7 @@ abstract class IntegrationTestBase {
     return documents
   }
 
-  protected fun verifyDocumentMetadataUpdated(documentUUID: UUID, status: String) {
+  protected fun verifyDocumentMetadataUpdated(documentUUID: UUID, status: String, caseReferences: List<String>? = emptyList()) {
     await untilAsserted {
       documentManagementApi.verify(
         WireMock.patchRequestedFor(WireMock.urlEqualTo("/documents/$documentUUID/metadata"))
@@ -845,6 +845,7 @@ abstract class IntegrationTestBase {
             WireMock.equalToJson(
               documentMetadataRequest(
                 status,
+                caseReferences?.joinToString(",") ?: "",
               ),
             ),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtappearance/CreateCourtAppearanceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtappearance/CreateCourtAppearanceTests.kt
@@ -59,7 +59,9 @@ class CreateCourtAppearanceTests : IntegrationTestBase() {
     val linkedDocument = uploadedDocumentRepository.findByDocumentUuid(uploadedDocument.documentUUID)
     assertThat(linkedDocument).isNotNull
     assertThat(linkedDocument!!.appearance?.appearanceUuid).isEqualTo(createCourtAppearance.appearanceUuid)
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE")
+
+    val caseReferences = createdCourtCase.appearances.mapNotNull { it.courtCaseReference }
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test
@@ -96,7 +98,9 @@ class CreateCourtAppearanceTests : IntegrationTestBase() {
     val linkedDocument = uploadedDocumentRepository.findByDocumentUuid(uploadedDocument.documentUUID)
     assertThat(linkedDocument).isNotNull
     assertThat(linkedDocument!!.appearance?.appearanceUuid).isEqualTo(createCourtAppearance.appearanceUuid)
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE")
+
+    val caseReferences = createdCourtCase.appearances.mapNotNull { it.courtCaseReference }
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtappearance/CreateCourtAppearanceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtappearance/CreateCourtAppearanceTests.kt
@@ -60,8 +60,7 @@ class CreateCourtAppearanceTests : IntegrationTestBase() {
     assertThat(linkedDocument).isNotNull
     assertThat(linkedDocument!!.appearance?.appearanceUuid).isEqualTo(createCourtAppearance.appearanceUuid)
 
-    val caseReferences = createdCourtCase.appearances.mapNotNull { it.courtCaseReference }
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", "GH123456789")
   }
 
   @Test
@@ -99,8 +98,7 @@ class CreateCourtAppearanceTests : IntegrationTestBase() {
     assertThat(linkedDocument).isNotNull
     assertThat(linkedDocument!!.appearance?.appearanceUuid).isEqualTo(createCourtAppearance.appearanceUuid)
 
-    val caseReferences = createdCourtCase.appearances.mapNotNull { it.courtCaseReference }
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", "GH123456789")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtappearance/UpdateCourtAppearanceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtappearance/UpdateCourtAppearanceTests.kt
@@ -92,8 +92,7 @@ class UpdateCourtAppearanceTests : IntegrationTestBase() {
     assertThat(newDoc).isNotNull
     assertThat(newDoc!!.appearance?.appearanceUuid).isEqualTo(createdAppearance.appearanceUuid)
 
-    val caseReferences = listOfNotNull(updateCourtAppearance.courtCaseReference)
-    verifyDocumentMetadataUpdated(newDocument.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(newDocument.documentUUID, "ACTIVE", "ADIFFERENTCOURTCASEREFERENCE")
   }
 
   @Test
@@ -152,8 +151,7 @@ class UpdateCourtAppearanceTests : IntegrationTestBase() {
     assertThat(newDoc).isNotNull
     assertThat(newDoc!!.appearance?.appearanceUuid).isEqualTo(createdAppearance.appearanceUuid)
 
-    val caseReferences = listOfNotNull(updateCourtAppearance.courtCaseReference)
-    verifyDocumentMetadataUpdated(newDocument.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(newDocument.documentUUID, "ACTIVE", "ADIFFERENTCOURTCASEREFERENCE")
   }
 
   @Test
@@ -180,8 +178,7 @@ class UpdateCourtAppearanceTests : IntegrationTestBase() {
     putCourtAppearance(createdAppearance.appearanceUuid, updateCourtAppearance)
 
     verifyDocumentMetadataUpdated(docA.documentUUID, "DELETED")
-    val caseReferences = listOfNotNull(updateCourtAppearance.courtCaseReference)
-    verifyDocumentMetadataUpdated(docC.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(docC.documentUUID, "ACTIVE", "GH123456789")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtappearance/UpdateCourtAppearanceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtappearance/UpdateCourtAppearanceTests.kt
@@ -92,7 +92,8 @@ class UpdateCourtAppearanceTests : IntegrationTestBase() {
     assertThat(newDoc).isNotNull
     assertThat(newDoc!!.appearance?.appearanceUuid).isEqualTo(createdAppearance.appearanceUuid)
 
-    verifyDocumentMetadataUpdated(newDocument.documentUUID, "ACTIVE")
+    val caseReferences = listOfNotNull(updateCourtAppearance.courtCaseReference)
+    verifyDocumentMetadataUpdated(newDocument.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test
@@ -151,7 +152,8 @@ class UpdateCourtAppearanceTests : IntegrationTestBase() {
     assertThat(newDoc).isNotNull
     assertThat(newDoc!!.appearance?.appearanceUuid).isEqualTo(createdAppearance.appearanceUuid)
 
-    verifyDocumentMetadataUpdated(newDocument.documentUUID, "ACTIVE")
+    val caseReferences = listOfNotNull(updateCourtAppearance.courtCaseReference)
+    verifyDocumentMetadataUpdated(newDocument.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test
@@ -178,7 +180,8 @@ class UpdateCourtAppearanceTests : IntegrationTestBase() {
     putCourtAppearance(createdAppearance.appearanceUuid, updateCourtAppearance)
 
     verifyDocumentMetadataUpdated(docA.documentUUID, "DELETED")
-    verifyDocumentMetadataUpdated(docC.documentUUID, "ACTIVE")
+    val caseReferences = listOfNotNull(updateCourtAppearance.courtCaseReference)
+    verifyDocumentMetadataUpdated(docC.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/CreateCourtCaseTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/CreateCourtCaseTests.kt
@@ -66,7 +66,8 @@ class CreateCourtCaseTests : IntegrationTestBase() {
         Assertions.assertThat(courtCaseUuid).matches("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})")
       }
 
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE")
+    val caseReferences = createCourtCase.appearances.mapNotNull { it.courtCaseReference }
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test
@@ -95,7 +96,8 @@ class CreateCourtCaseTests : IntegrationTestBase() {
         Assertions.assertThat(courtCaseUuid).matches("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})")
       }
 
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE")
+    val caseReferences = createCourtCase.appearances.mapNotNull { it.courtCaseReference }
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/CreateCourtCaseTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/CreateCourtCaseTests.kt
@@ -66,8 +66,7 @@ class CreateCourtCaseTests : IntegrationTestBase() {
         Assertions.assertThat(courtCaseUuid).matches("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})")
       }
 
-    val caseReferences = createCourtCase.appearances.mapNotNull { it.courtCaseReference }
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", "GH123456789")
   }
 
   @Test
@@ -96,8 +95,7 @@ class CreateCourtCaseTests : IntegrationTestBase() {
         Assertions.assertThat(courtCaseUuid).matches("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})")
       }
 
-    val caseReferences = createCourtCase.appearances.mapNotNull { it.courtCaseReference }
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", "GH123456789")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/UpdateCourtCaseTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/UpdateCourtCaseTests.kt
@@ -65,8 +65,7 @@ class UpdateCourtCaseTests : IntegrationTestBase() {
       .expectStatus()
       .isOk
 
-    val caseReferences = editedCourtCase.appearances.mapNotNull { it.courtCaseReference }
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", "ADIFFERENTCOURTCASEREFERENCE")
   }
 
   @Test
@@ -91,8 +90,7 @@ class UpdateCourtCaseTests : IntegrationTestBase() {
       .expectStatus()
       .isOk
 
-    val caseReferences = editedCourtCase.appearances.mapNotNull { it.courtCaseReference }
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", "ADIFFERENTCOURTCASEREFERENCE")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/UpdateCourtCaseTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/courtcase/UpdateCourtCaseTests.kt
@@ -65,7 +65,8 @@ class UpdateCourtCaseTests : IntegrationTestBase() {
       .expectStatus()
       .isOk
 
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE")
+    val caseReferences = editedCourtCase.appearances.mapNotNull { it.courtCaseReference }
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test
@@ -90,7 +91,8 @@ class UpdateCourtCaseTests : IntegrationTestBase() {
       .expectStatus()
       .isOk
 
-    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE")
+    val caseReferences = editedCourtCase.appearances.mapNotNull { it.courtCaseReference }
+    verifyDocumentMetadataUpdated(uploadedDocument.documentUUID, "ACTIVE", caseReferences)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/requests/documentManagementApi/DocumentMetadataRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/requests/documentManagementApi/DocumentMetadataRequest.kt
@@ -1,7 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.requests.documentManagementApi
 
-fun documentMetadataRequest(status: String) = """
-  {
-     "status":"$status"
+fun documentMetadataRequest(status: String, caseReferences: String): String {
+  val caseReferencesList = if (!caseReferences.isEmpty()) {
+    """
+      ,
+      "caseReferences": [ "$caseReferences" ]
+    """.trimIndent()
+  } else {
+    ""
   }
-""".trimIndent()
+
+  return """
+    {
+       "status":"$status",
+       "isUnread":false
+       $caseReferencesList
+    }
+  """.trimIndent()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/requests/documentManagementApi/DocumentMetadataRequest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/integration/requests/documentManagementApi/DocumentMetadataRequest.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsremandandsentencingapi.integration.requests.documentManagementApi
 
-fun documentMetadataRequest(status: String, caseReferences: String): String {
-  val caseReferencesList = if (!caseReferences.isEmpty()) {
+fun documentMetadataRequest(status: String, caseReference: String?): String {
+  val caseReferencesList = if (!caseReference.isNullOrBlank()) {
     """
       ,
-      "caseReferences": [ "$caseReferences" ]
+      "caseReferences": [ "$caseReference" ]
     """.trimIndent()
   } else {
     ""

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/CourtCaseReferenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/CourtCaseReferenceServiceTests.kt
@@ -45,10 +45,13 @@ class CourtCaseReferenceServiceTests {
     courtCase.appearances = setOf(activeCourtAppearance)
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
-    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+
+    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+
     val caseReferences = courtCase.legacyData!!.caseReferences
     Assertions.assertThat(caseReferences).hasSize(1).extracting<String> { it.offenderCaseReference }
       .contains(activeCourtAppearance.courtCaseReference!!)
+    Assertions.assertThat(updatedCourtCases?.caseReferences).hasSize(1).contains(activeCourtAppearance.courtCaseReference!!)
   }
 
   @Test
@@ -60,10 +63,13 @@ class CourtCaseReferenceServiceTests {
     courtCase.appearances = setOf(deletedCourtAppearance)
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
-    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+
+    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+
     val caseReferences = courtCase.legacyData!!.caseReferences
     Assertions.assertThat(caseReferences).hasSize(0).extracting<String> { it.offenderCaseReference }
       .doesNotContain(deletedCourtAppearance.courtCaseReference!!)
+    Assertions.assertThat(updatedCourtCases?.caseReferences).hasSize(0).doesNotContain(deletedCourtAppearance.courtCaseReference!!)
   }
 
   @Test
@@ -77,16 +83,18 @@ class CourtCaseReferenceServiceTests {
     courtCase.appearances = setOf(activeCourtAppearance, deletedCourtAppearance)
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
-    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+
+    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+
     val caseReferences = courtCase.legacyData!!.caseReferences
     Assertions.assertThat(caseReferences).hasSize(5).extracting<String> { it.offenderCaseReference }
       .containsExactlyInAnyOrder("ANEWREFERENCE", *existingReferences.toTypedArray())
+    Assertions.assertThat(updatedCourtCases?.caseReferences).hasSize(5).containsExactlyInAnyOrder("ANEWREFERENCE", *existingReferences.toTypedArray())
   }
 
   @Test
   fun `remove DPS legacy refs not on active appearances but keep NOMIS ones`() {
     val courtCase = CourtCaseEntity.from(DpsDataCreator.dpsCreateCourtCase(), "U")
-
     val nomisRef = "NOMIS-CASE-REFERENCE"
     val dpsRef = "DPS-CASE-REFERENCE"
     courtCase.legacyData = CourtCaseLegacyData(
@@ -96,17 +104,16 @@ class CourtCaseReferenceServiceTests {
       ),
       1L,
     )
-
     val active = generateCourtAppearance("ACTIVE-CASE-REF", CourtAppearanceEntityStatus.ACTIVE, courtCase)
     courtCase.appearances = setOf(active)
-
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
 
-    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
 
     val refs = courtCase.legacyData!!.caseReferences.map { it.offenderCaseReference }
     Assertions.assertThat(refs).containsExactlyInAnyOrder("ACTIVE-CASE-REF", nomisRef)
+    Assertions.assertThat(updatedCourtCases?.caseReferences).containsExactlyInAnyOrder("ACTIVE-CASE-REF", nomisRef)
   }
 
   @Test
@@ -115,21 +122,20 @@ class CourtCaseReferenceServiceTests {
     val newRef = "ANEWREFERENCE"
     val courtCase = CourtCaseEntity.from(DpsDataCreator.dpsCreateCourtCase(), "U")
     courtCase.legacyData = generateLegacyData(listOf(oldRef))
-
     val stillUsingOld = generateCourtAppearance(oldRef, CourtAppearanceEntityStatus.ACTIVE, courtCase)
     val editedToNew = generateCourtAppearance(newRef, CourtAppearanceEntityStatus.ACTIVE, courtCase)
     courtCase.appearances = setOf(stillUsingOld, editedToNew)
-
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
 
-    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
 
     val caseReferences = courtCase.legacyData!!.caseReferences
     Assertions.assertThat(caseReferences)
       .hasSize(2)
       .extracting<String> { it.offenderCaseReference }
       .containsExactlyInAnyOrder(oldRef, newRef)
+    Assertions.assertThat(updatedCourtCases?.caseReferences).hasSize(2).containsExactlyInAnyOrder(oldRef, newRef)
   }
 
   private fun generateLegacyData(caseReferences: List<String>): CourtCaseLegacyData = CourtCaseLegacyData(caseReferences.map { CaseReferenceLegacyData(it, LocalDateTime.now()) }.toMutableList(), 1L)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/CourtCaseReferenceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsremandandsentencingapi/service/CourtCaseReferenceServiceTests.kt
@@ -46,12 +46,11 @@ class CourtCaseReferenceServiceTests {
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
 
-    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
 
     val caseReferences = courtCase.legacyData!!.caseReferences
     Assertions.assertThat(caseReferences).hasSize(1).extracting<String> { it.offenderCaseReference }
       .contains(activeCourtAppearance.courtCaseReference!!)
-    Assertions.assertThat(updatedCourtCases?.caseReferences).hasSize(1).contains(activeCourtAppearance.courtCaseReference!!)
   }
 
   @Test
@@ -64,12 +63,11 @@ class CourtCaseReferenceServiceTests {
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
 
-    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
 
     val caseReferences = courtCase.legacyData!!.caseReferences
     Assertions.assertThat(caseReferences).hasSize(0).extracting<String> { it.offenderCaseReference }
       .doesNotContain(deletedCourtAppearance.courtCaseReference!!)
-    Assertions.assertThat(updatedCourtCases?.caseReferences).hasSize(0).doesNotContain(deletedCourtAppearance.courtCaseReference!!)
   }
 
   @Test
@@ -84,12 +82,11 @@ class CourtCaseReferenceServiceTests {
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
 
-    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
 
     val caseReferences = courtCase.legacyData!!.caseReferences
     Assertions.assertThat(caseReferences).hasSize(5).extracting<String> { it.offenderCaseReference }
       .containsExactlyInAnyOrder("ANEWREFERENCE", *existingReferences.toTypedArray())
-    Assertions.assertThat(updatedCourtCases?.caseReferences).hasSize(5).containsExactlyInAnyOrder("ANEWREFERENCE", *existingReferences.toTypedArray())
   }
 
   @Test
@@ -109,11 +106,10 @@ class CourtCaseReferenceServiceTests {
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
 
-    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
 
     val refs = courtCase.legacyData!!.caseReferences.map { it.offenderCaseReference }
     Assertions.assertThat(refs).containsExactlyInAnyOrder("ACTIVE-CASE-REF", nomisRef)
-    Assertions.assertThat(updatedCourtCases?.caseReferences).containsExactlyInAnyOrder("ACTIVE-CASE-REF", nomisRef)
   }
 
   @Test
@@ -128,14 +124,13 @@ class CourtCaseReferenceServiceTests {
     every { courtCaseRepository.findByCaseUniqueIdentifier(courtCase.caseUniqueIdentifier) } returns courtCase
     every { courtCaseHistoryRepository.save(any()) } returns mockk()
 
-    val updatedCourtCases = courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
+    courtCaseReferenceService.updateCourtCaseReferences(courtCase.caseUniqueIdentifier)
 
     val caseReferences = courtCase.legacyData!!.caseReferences
     Assertions.assertThat(caseReferences)
       .hasSize(2)
       .extracting<String> { it.offenderCaseReference }
       .containsExactlyInAnyOrder(oldRef, newRef)
-    Assertions.assertThat(updatedCourtCases?.caseReferences).hasSize(2).containsExactlyInAnyOrder(oldRef, newRef)
   }
 
   private fun generateLegacyData(caseReferences: List<String>): CourtCaseLegacyData = CourtCaseLegacyData(caseReferences.map { CaseReferenceLegacyData(it, LocalDateTime.now()) }.toMutableList(), 1L)


### PR DESCRIPTION
CDIA-266: Add case references to uploaded document metadata. 
The idea is to take the opportunity of updating the document status (when the change is to ACTIVE), to also have the case references added to the metadata